### PR TITLE
Fix failing tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,4 +108,7 @@ local.properties
 # Ignore all local history of files
 .history
 
+# Ignore log files
+*.log
+
 # End of https://www.gitignore.io/api/c,c++,eclipse,visualstudiocode

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+export CC=gcc
+export CXX=g++
+
 # make clean build dir
 [ -d build ] && rm -r build && mkdir build
 
@@ -10,5 +13,5 @@ cmake -S . -B build
 cmake --build build -j4 -v
 
 # run tests
-cd build && make test
+cd build && ctest
 cd ../

--- a/test/core/generate_mipmaps_sampler1d.cpp
+++ b/test/core/generate_mipmaps_sampler1d.cpp
@@ -37,7 +37,7 @@ namespace generate_mipmaps
 		gli::texture1d TextureView(gli::view(Texture, 0, 0));
 		gli::fsampler1D SamplerA(gli::texture1d(gli::duplicate(Texture)), gli::WRAP_CLAMP_TO_EDGE);
 
-		// generate mipmaps via linear filtering and get
+		// generate mipmaps via filtering and get
 		SamplerA.generate_mipmaps(Filter);
 		gli::texture1d MipmapsA = SamplerA();
 
@@ -47,7 +47,7 @@ namespace generate_mipmaps
 		Error += (TopTexelA == TargetColor) ? 0 : 1;
 
 		// if texture has multiple mipmap levels, texel from top level can't match texel from original texture
-		if(Texture.levels() > 1)
+		if (Texture.levels() > 1)
 			Error += (TopTexelA != TopTexel) ? 0 : 1;
 
 		// create mipmaps view (should match texture view)
@@ -63,7 +63,7 @@ namespace generate_mipmaps
 		Error += (TopTexelB == TargetColor) ? 0 : 1;
 
 		// if texture has multiple levels, texel from top level can't match texel from original texture
-		if(Texture.levels() > 1)
+		if (Texture.levels() > 1)
 			Error += (TopTexelB != TopTexel) ? 0 : 1;
 
 		// create mipmaps view and match against texture view

--- a/test/core/generate_mipmaps_sampler1d.cpp
+++ b/test/core/generate_mipmaps_sampler1d.cpp
@@ -21,13 +21,13 @@ namespace generate_mipmaps
 
 		// create 1-D texture of appropriate size and clear with texels of given colors
 		gli::texture1d Texture(Format,
-				static_cast<gli::texture1d::extent_type>(static_cast<gli::texture1d::extent_type::value_type>(Size)));
+			static_cast<gli::texture1d::extent_type>(static_cast<gli::texture1d::extent_type::value_type>(Size)));
 		Texture.clear(BaseColor);
 		Texture[0].clear(TargetColor);
 
 		// get texel at position #0 from top mipmap level
 		const genType TopTexel = Texture.load<genType>(static_cast<gli::texture1d::extent_type>(0),
-				Texture.max_level());
+			Texture.max_level());
 
 		// If texture has multiple mipmap levels, texel from top level must match base color
 		if (Texture.levels() > 1)
@@ -43,7 +43,7 @@ namespace generate_mipmaps
 
 		// get texel at position #0 from top mipmap level (should match target color)
 		const genType TopTexelA = MipmapsA.load<genType>(static_cast<gli::texture1d::extent_type>(0),
-				MipmapsA.max_level());
+			MipmapsA.max_level());
 		Error += (TopTexelA == TargetColor) ? 0 : 1;
 
 		// if texture has multiple mipmap levels, texel from top level can't match texel from original texture
@@ -59,7 +59,7 @@ namespace generate_mipmaps
 
 		// load texel at position #0 from top mipmap level (should match target color)
 		const genType TopTexelB = MipmapsB.load<genType>(static_cast<gli::texture1d::extent_type>(0),
-				MipmapsB.max_level());
+			MipmapsB.max_level());
 		Error += (TopTexelB == TargetColor) ? 0 : 1;
 
 		// if texture has multiple levels, texel from top level can't match texel from original texture
@@ -72,8 +72,6 @@ namespace generate_mipmaps
 
 		// Compare custom mipmaps generation and wrapper mipmaps generation
 		Error += (MipmapsViewA == MipmapsViewB) ? 0 : 1;
-
-		// TODO: comparison failing for Size >= 24
 		Error += (MipmapsA == MipmapsB) ? 0 : 1;
 
 		return Error;
@@ -97,88 +95,88 @@ int main()
 	for (const auto Filter: Filters) {
 		for (const auto Size: Sizes) {
 			Error += generate_mipmaps::test(gli::FORMAT_R16_SFLOAT_PACK16,
-					gli::packHalf(glm::vec1(0.0f)),
-					gli::packHalf(glm::vec1(1.0f)),
-					Size,
-					Filter);
+				gli::packHalf(glm::vec1(0.0f)),
+				gli::packHalf(glm::vec1(1.0f)),
+				Size,
+				Filter);
 
 			Error += generate_mipmaps::test(gli::FORMAT_RG16_SFLOAT_PACK16,
-					gli::packHalf(glm::vec2(0.0f, 0.0f)),
-					gli::packHalf(glm::vec2(1.0f, 0.5f)),
-					Size,
-					Filter);
+				gli::packHalf(glm::vec2(0.0f, 0.0f)),
+				gli::packHalf(glm::vec2(1.0f, 0.5f)),
+				Size,
+				Filter);
 
 			Error += generate_mipmaps::test(gli::FORMAT_RGB16_SFLOAT_PACK16,
-					gli::packHalf(glm::vec3(0.0f, 0.0f, 0.0f)),
-					gli::packHalf(glm::vec3(1.0f, 0.5f, 0.0f)),
-					Size,
-					Filter);
+				gli::packHalf(glm::vec3(0.0f, 0.0f, 0.0f)),
+				gli::packHalf(glm::vec3(1.0f, 0.5f, 0.0f)),
+				Size,
+				Filter);
 
 			Error += generate_mipmaps::test(gli::FORMAT_RGBA16_SFLOAT_PACK16,
-					gli::packHalf(glm::vec4(0.0f, 0.0f, 0.0f, 0.0f)),
-					gli::packHalf(glm::vec4(1.0f, 0.5f, 0.0f, 1.0f)),
-					Size,
-					Filter);
+				gli::packHalf(glm::vec4(0.0f, 0.0f, 0.0f, 0.0f)),
+				gli::packHalf(glm::vec4(1.0f, 0.5f, 0.0f, 1.0f)),
+				Size,
+				Filter);
 
 			Error += generate_mipmaps::test(gli::FORMAT_R32_SFLOAT_PACK32,
-					glm::vec1(0.0f),
-					glm::vec1(1.0f),
-					Size,
-					Filter);
+				glm::vec1(0.0f),
+				glm::vec1(1.0f),
+				Size,
+				Filter);
 
 			Error += generate_mipmaps::test(gli::FORMAT_RG32_SFLOAT_PACK32,
-					glm::vec2(0.0f, 0.0f),
-					glm::vec2(1.0f, 0.5f),
-					Size,
-					Filter);
+				glm::vec2(0.0f, 0.0f),
+				glm::vec2(1.0f, 0.5f),
+				Size,
+				Filter);
 
 			Error += generate_mipmaps::test(gli::FORMAT_RGB32_SFLOAT_PACK32,
-					glm::vec3(0.0f, 0.0f, 0.0f),
-					glm::vec3(1.0f, 0.5f, 0.0f),
-					Size,
-					Filter);
+				glm::vec3(0.0f, 0.0f, 0.0f),
+				glm::vec3(1.0f, 0.5f, 0.0f),
+				Size,
+				Filter);
 
 			Error += generate_mipmaps::test(gli::FORMAT_RGBA32_SFLOAT_PACK32,
-					glm::vec4(0.0f, 0.0f, 0.0f, 0.0f),
-					glm::vec4(1.0f, 0.5f, 0.0f, 1.0f),
-					Size,
-					Filter);
+				glm::vec4(0.0f, 0.0f, 0.0f, 0.0f),
+				glm::vec4(1.0f, 0.5f, 0.0f, 1.0f),
+				Size,
+				Filter);
 
 			Error += generate_mipmaps::test(gli::FORMAT_RGBA4_UNORM_PACK16,
-					gli::packUnorm4x4(glm::vec4(0.0f, 0.0f, 0.0f, 0.0f)),
-					gli::packUnorm4x4(glm::vec4(1.0f, 0.5f, 0.0f, 1.0f)),
-					Size,
-					Filter);
+				gli::packUnorm4x4(glm::vec4(0.0f, 0.0f, 0.0f, 0.0f)),
+				gli::packUnorm4x4(glm::vec4(1.0f, 0.5f, 0.0f, 1.0f)),
+				Size,
+				Filter);
 
 			Error += generate_mipmaps::test(gli::FORMAT_RGBA8_UNORM_PACK8,
-					glm::u8vec4(0, 0, 0, 0),
-					glm::u8vec4(255, 127, 0, 255),
-					Size,
-					Filter);
+				glm::u8vec4(0, 0, 0, 0),
+				glm::u8vec4(255, 127, 0, 255),
+				Size,
+				Filter);
 
 			Error += generate_mipmaps::test(gli::FORMAT_RGBA8_SNORM_PACK8,
-					glm::i8vec4(0, 0, 0, 0),
-					glm::i8vec4(127, 63, 0, 1),
-					Size,
-					Filter);
+				glm::i8vec4(0, 0, 0, 0),
+				glm::i8vec4(127, 63, 0, 1),
+				Size,
+				Filter);
 
 			Error += generate_mipmaps::test(gli::FORMAT_RGB10A2_UNORM_PACK32,
-					gli::packUnorm3x10_1x2(glm::vec4(0.0f, 0.0f, 0.0f, 0.0f)),
-					gli::packUnorm3x10_1x2(glm::vec4(1.0f, 0.5f, 0.0f, 1.0f)),
-					Size,
-					Filter);
+				gli::packUnorm3x10_1x2(glm::vec4(0.0f, 0.0f, 0.0f, 0.0f)),
+				gli::packUnorm3x10_1x2(glm::vec4(1.0f, 0.5f, 0.0f, 1.0f)),
+				Size,
+				Filter);
 
 			Error += generate_mipmaps::test(gli::FORMAT_RGB10A2_SNORM_PACK32,
-					gli::packSnorm3x10_1x2(glm::vec4(0.0f, 0.0f, 0.0f, 0.0f)),
-					gli::packSnorm3x10_1x2(glm::vec4(1.0f, 0.5f, 0.0f, 1.0f)),
-					Size,
-					Filter);
+				gli::packSnorm3x10_1x2(glm::vec4(0.0f, 0.0f, 0.0f, 0.0f)),
+				gli::packSnorm3x10_1x2(glm::vec4(1.0f, 0.5f, 0.0f, 1.0f)),
+				Size,
+				Filter);
 
 			Error += generate_mipmaps::test(gli::FORMAT_RGB9E5_UFLOAT_PACK32,
-					gli::packF3x9_E1x5(glm::vec3(0.0f, 0.0f, 0.0f)),
-					gli::packF3x9_E1x5(glm::vec3(1.0f, 0.5f, 0.0f)),
-					Size,
-					Filter);
+				gli::packF3x9_E1x5(glm::vec3(0.0f, 0.0f, 0.0f)),
+				gli::packF3x9_E1x5(glm::vec3(1.0f, 0.5f, 0.0f)),
+				Size,
+				Filter);
 		}
 	}
 

--- a/test/core/generate_mipmaps_sampler1d.cpp
+++ b/test/core/generate_mipmaps_sampler1d.cpp
@@ -1,3 +1,9 @@
+/*
+ * Tests for loading texels and generating mipmaps (1-D textures + texture sampler)
+ */
+
+#include <vector>
+
 #include <gli/comparison.hpp>
 #include <gli/type.hpp>
 #include <gli/view.hpp>
@@ -9,139 +15,171 @@
 namespace generate_mipmaps
 {
 	template <typename genType>
-	int test(gli::format Format, genType const & Black, genType const & Color, std::size_t Size, gli::filter Filter)
+	int test(gli::format Format, const genType& BaseColor, const genType& TargetColor, std::size_t Size, gli::filter Filter)
 	{
 		int Error = 0;
 
-		gli::texture1d Texture(Format, gli::texture1d::extent_type(static_cast<gli::texture1d::extent_type::value_type>(Size)));
-		Texture.clear(Black);
-		Texture[0].clear(Color);
+		// create 1-D texture of appropriate size and clear with texels of given colors
+		gli::texture1d Texture(Format,
+				static_cast<gli::texture1d::extent_type>(static_cast<gli::texture1d::extent_type::value_type>(Size)));
+		Texture.clear(BaseColor);
+		Texture[0].clear(TargetColor);
 
-		genType const LoadC = Texture.load<genType>(gli::texture1d::extent_type(0), Texture.max_level());
-		if(Texture.levels() > 1)
-			Error += LoadC == Black ? 0 : 1;
+		// get texel at position #0 from top mipmap level
+		const genType TopTexel = Texture.load<genType>(static_cast<gli::texture1d::extent_type>(0),
+				Texture.max_level());
 
+		// If texture has multiple mipmap levels, texel from top level must match base color
+		if (Texture.levels() > 1)
+			Error += (TopTexel == BaseColor) ? 0 : 1;
+
+		// create a texture view and a sampler
 		gli::texture1d TextureView(gli::view(Texture, 0, 0));
 		gli::fsampler1D SamplerA(gli::texture1d(gli::duplicate(Texture)), gli::WRAP_CLAMP_TO_EDGE);
-		SamplerA.generate_mipmaps(gli::FILTER_LINEAR);
 
+		// generate mipmaps via linear filtering and get
+		SamplerA.generate_mipmaps(Filter);
 		gli::texture1d MipmapsA = SamplerA();
-		genType const LoadA = MipmapsA.load<genType>(gli::texture1d::extent_type(0), MipmapsA.max_level());
-		Error += LoadA == Color ? 0 : 1;
-		if(Texture.levels() > 1)
-			Error += LoadA != LoadC ? 0 : 1;
 
-		gli::texture1d MipmapViewA(gli::view(MipmapsA, 0, 0));
-		Error += TextureView == MipmapViewA ? 0 : 1;
+		// get texel at position #0 from top mipmap level (should match target color)
+		const genType TopTexelA = MipmapsA.load<genType>(static_cast<gli::texture1d::extent_type>(0),
+				MipmapsA.max_level());
+		Error += (TopTexelA == TargetColor) ? 0 : 1;
+
+		// if texture has multiple mipmap levels, texel from top level can't match texel from original texture
+		if(Texture.levels() > 1)
+			Error += (TopTexelA != TopTexel) ? 0 : 1;
+
+		// create mipmaps view (should match texture view)
+		gli::texture1d MipmapsViewA(gli::view(MipmapsA, 0, 0));
+		Error += (TextureView == MipmapsViewA) ? 0 : 1;
 
 		// Mipmaps generation using the wrapper function
 		gli::texture1d MipmapsB = gli::generate_mipmaps(gli::texture1d(gli::duplicate(Texture)), Filter);
-		genType const LoadB = MipmapsB.load<genType>(gli::texture1d::extent_type(0), MipmapsB.max_level());
-		Error += LoadB == Color ? 0 : 1;
-		if(Texture.levels() > 1)
-			Error += LoadB != LoadC ? 0 : 1;
 
-		gli::texture1d MipmapViewB(gli::view(MipmapsB, 0, 0));
-		Error += TextureView == MipmapViewB ? 0 : 1;
+		// load texel at position #0 from top mipmap level (should match target color)
+		const genType TopTexelB = MipmapsB.load<genType>(static_cast<gli::texture1d::extent_type>(0),
+				MipmapsB.max_level());
+		Error += (TopTexelB == TargetColor) ? 0 : 1;
+
+		// if texture has multiple levels, texel from top level can't match texel from original texture
+		if(Texture.levels() > 1)
+			Error += (TopTexelB != TopTexel) ? 0 : 1;
+
+		// create mipmaps view and match against texture view
+		gli::texture1d MipmapsViewB(gli::view(MipmapsB, 0, 0));
+		Error += (TextureView == MipmapsViewB) ? 0 : 1;
 
 		// Compare custom mipmaps generation and wrapper mipmaps generation
-		Error += MipmapViewA == MipmapViewB ? 0 : 1;
-		Error += MipmapsA == MipmapsB ? 0 : 1;
+		Error += (MipmapsViewA == MipmapsViewB) ? 0 : 1;
+
+		// TODO: comparison failing for Size >= 24
+		Error += (MipmapsA == MipmapsB) ? 0 : 1;
 
 		return Error;
 	}
-}//namespace generate_mipmaps
+} //namespace generate_mipmaps
 
 int main()
 {
 	int Error = 0;
 
-	std::vector<gli::filter> Filters;
-	Filters.push_back(gli::FILTER_NEAREST);
-	Filters.push_back(gli::FILTER_LINEAR);
+	// select filters for mipmap generation
+	std::vector<gli::filter> Filters = {
+		gli::FILTER_NEAREST,
+		gli::FILTER_LINEAR
+	};
 
-	std::vector<gli::size_t> Sizes;
-	Sizes.push_back(1);
-	Sizes.push_back(2);
-	Sizes.push_back(3);
-	Sizes.push_back(15);
-	Sizes.push_back(16);
-	Sizes.push_back(17);
-	Sizes.push_back(24);
-	Sizes.push_back(32);
+	// select texture sizes
+	std::vector<gli::size_t> Sizes = { 1, 2, 3, 4, 8, 16, 17, 24, 28, 32, 64, 128 };
 
-	for(std::size_t FilterIndex = 0, FilterCount = Filters.size(); FilterIndex < FilterCount; ++FilterIndex)
-	for(std::size_t SizeIndex = 0, SizeCount = Sizes.size(); SizeIndex < SizeCount; ++SizeIndex)
-	{
-		Error += generate_mipmaps::test(gli::FORMAT_R16_SFLOAT_PACK16,
-			gli::packHalf(glm::vec1(0.0f)),
-			gli::packHalf(glm::vec1(1.0f)),
-			Sizes[SizeIndex], Filters[FilterIndex]);
+	// run tests for each filter and size
+	for (const auto Filter: Filters) {
+		for (const auto Size: Sizes) {
+			Error += generate_mipmaps::test(gli::FORMAT_R16_SFLOAT_PACK16,
+					gli::packHalf(glm::vec1(0.0f)),
+					gli::packHalf(glm::vec1(1.0f)),
+					Size,
+					Filter);
 
-		Error += generate_mipmaps::test(gli::FORMAT_RG16_SFLOAT_PACK16,
-			gli::packHalf(glm::vec2(0.0f, 0.0f)),
-			gli::packHalf(glm::vec2(1.0f, 0.5f)),
-			Sizes[SizeIndex], Filters[FilterIndex]);
+			Error += generate_mipmaps::test(gli::FORMAT_RG16_SFLOAT_PACK16,
+					gli::packHalf(glm::vec2(0.0f, 0.0f)),
+					gli::packHalf(glm::vec2(1.0f, 0.5f)),
+					Size,
+					Filter);
 
-		Error += generate_mipmaps::test(gli::FORMAT_RGB16_SFLOAT_PACK16,
-			gli::packHalf(glm::vec3(0.0f, 0.0f, 0.0f)),
-			gli::packHalf(glm::vec3(1.0f, 0.5f, 0.0f)),
-			Sizes[SizeIndex], Filters[FilterIndex]);
+			Error += generate_mipmaps::test(gli::FORMAT_RGB16_SFLOAT_PACK16,
+					gli::packHalf(glm::vec3(0.0f, 0.0f, 0.0f)),
+					gli::packHalf(glm::vec3(1.0f, 0.5f, 0.0f)),
+					Size,
+					Filter);
 
-		Error += generate_mipmaps::test(gli::FORMAT_RGBA16_SFLOAT_PACK16,
-			gli::packHalf(glm::vec4(0.0f, 0.0f, 0.0f, 0.0f)),
-			gli::packHalf(glm::vec4(1.0f, 0.5f, 0.0f, 1.0f)),
-			Sizes[SizeIndex], Filters[FilterIndex]);
+			Error += generate_mipmaps::test(gli::FORMAT_RGBA16_SFLOAT_PACK16,
+					gli::packHalf(glm::vec4(0.0f, 0.0f, 0.0f, 0.0f)),
+					gli::packHalf(glm::vec4(1.0f, 0.5f, 0.0f, 1.0f)),
+					Size,
+					Filter);
 
-		Error += generate_mipmaps::test(gli::FORMAT_R32_SFLOAT_PACK32,
-			glm::vec1(0.0f),
-			glm::vec1(1.0f),
-			Sizes[SizeIndex], Filters[FilterIndex]);
+			Error += generate_mipmaps::test(gli::FORMAT_R32_SFLOAT_PACK32,
+					glm::vec1(0.0f),
+					glm::vec1(1.0f),
+					Size,
+					Filter);
 
-		Error += generate_mipmaps::test(gli::FORMAT_RG32_SFLOAT_PACK32,
-			glm::vec2(0.0f, 0.0f),
-			glm::vec2(1.0f, 0.5f),
-			Sizes[SizeIndex], Filters[FilterIndex]);
+			Error += generate_mipmaps::test(gli::FORMAT_RG32_SFLOAT_PACK32,
+					glm::vec2(0.0f, 0.0f),
+					glm::vec2(1.0f, 0.5f),
+					Size,
+					Filter);
 
-		Error += generate_mipmaps::test(gli::FORMAT_RGB32_SFLOAT_PACK32,
-			glm::vec3(0.0f, 0.0f, 0.0f),
-			glm::vec3(1.0f, 0.5f, 0.0f),
-			Sizes[SizeIndex], Filters[FilterIndex]);
+			Error += generate_mipmaps::test(gli::FORMAT_RGB32_SFLOAT_PACK32,
+					glm::vec3(0.0f, 0.0f, 0.0f),
+					glm::vec3(1.0f, 0.5f, 0.0f),
+					Size,
+					Filter);
 
-		Error += generate_mipmaps::test(gli::FORMAT_RGBA32_SFLOAT_PACK32,
-			glm::vec4(0.0f, 0.0f, 0.0f, 0.0f),
-			glm::vec4(1.0f, 0.5f, 0.0f, 1.0f),
-			Sizes[SizeIndex], Filters[FilterIndex]);
+			Error += generate_mipmaps::test(gli::FORMAT_RGBA32_SFLOAT_PACK32,
+					glm::vec4(0.0f, 0.0f, 0.0f, 0.0f),
+					glm::vec4(1.0f, 0.5f, 0.0f, 1.0f),
+					Size,
+					Filter);
 
-		Error += generate_mipmaps::test(gli::FORMAT_RGBA4_UNORM_PACK16,
-			gli::packUnorm4x4(glm::vec4(0.0f, 0.0f, 0.0f, 0.0f)),
-			gli::packUnorm4x4(glm::vec4(1.0f, 0.5f, 0.0f, 1.0f)),
-			Sizes[SizeIndex], Filters[FilterIndex]);
+			Error += generate_mipmaps::test(gli::FORMAT_RGBA4_UNORM_PACK16,
+					gli::packUnorm4x4(glm::vec4(0.0f, 0.0f, 0.0f, 0.0f)),
+					gli::packUnorm4x4(glm::vec4(1.0f, 0.5f, 0.0f, 1.0f)),
+					Size,
+					Filter);
 
-		Error += generate_mipmaps::test(gli::FORMAT_RGBA8_UNORM_PACK8,
-			glm::u8vec4(0, 0, 0, 0),
-			glm::u8vec4(255, 127, 0, 255),
-			Sizes[SizeIndex], Filters[FilterIndex]);
+			Error += generate_mipmaps::test(gli::FORMAT_RGBA8_UNORM_PACK8,
+					glm::u8vec4(0, 0, 0, 0),
+					glm::u8vec4(255, 127, 0, 255),
+					Size,
+					Filter);
 
-		Error += generate_mipmaps::test(gli::FORMAT_RGBA8_SNORM_PACK8,
-			glm::i8vec4(0, 0, 0, 0),
-			glm::i8vec4(127, 63, 0, 1),
-			Sizes[SizeIndex], Filters[FilterIndex]);
+			Error += generate_mipmaps::test(gli::FORMAT_RGBA8_SNORM_PACK8,
+					glm::i8vec4(0, 0, 0, 0),
+					glm::i8vec4(127, 63, 0, 1),
+					Size,
+					Filter);
 
-		Error += generate_mipmaps::test(gli::FORMAT_RGB10A2_UNORM_PACK32,
-			gli::packUnorm3x10_1x2(glm::vec4(0.0f, 0.0f, 0.0f, 0.0f)),
-			gli::packUnorm3x10_1x2(glm::vec4(1.0f, 0.5f, 0.0f, 1.0f)),
-			Sizes[SizeIndex], Filters[FilterIndex]);
+			Error += generate_mipmaps::test(gli::FORMAT_RGB10A2_UNORM_PACK32,
+					gli::packUnorm3x10_1x2(glm::vec4(0.0f, 0.0f, 0.0f, 0.0f)),
+					gli::packUnorm3x10_1x2(glm::vec4(1.0f, 0.5f, 0.0f, 1.0f)),
+					Size,
+					Filter);
 
-		Error += generate_mipmaps::test(gli::FORMAT_RGB10A2_SNORM_PACK32,
-			gli::packSnorm3x10_1x2(glm::vec4(0.0f, 0.0f, 0.0f, 0.0f)),
-			gli::packSnorm3x10_1x2(glm::vec4(1.0f, 0.5f, 0.0f, 1.0f)),
-			Sizes[SizeIndex], Filters[FilterIndex]);
+			Error += generate_mipmaps::test(gli::FORMAT_RGB10A2_SNORM_PACK32,
+					gli::packSnorm3x10_1x2(glm::vec4(0.0f, 0.0f, 0.0f, 0.0f)),
+					gli::packSnorm3x10_1x2(glm::vec4(1.0f, 0.5f, 0.0f, 1.0f)),
+					Size,
+					Filter);
 
-		Error += generate_mipmaps::test(gli::FORMAT_RGB9E5_UFLOAT_PACK32,
-			gli::packF3x9_E1x5(glm::vec3(0.0f, 0.0f, 0.0f)),
-			gli::packF3x9_E1x5(glm::vec3(1.0f, 0.5f, 0.0f)),
-			Sizes[SizeIndex], Filters[FilterIndex]);
+			Error += generate_mipmaps::test(gli::FORMAT_RGB9E5_UFLOAT_PACK32,
+					gli::packF3x9_E1x5(glm::vec3(0.0f, 0.0f, 0.0f)),
+					gli::packF3x9_E1x5(glm::vec3(1.0f, 0.5f, 0.0f)),
+					Size,
+					Filter);
+		}
 	}
 
 	return Error;

--- a/test/core/generate_mipmaps_sampler2d.cpp
+++ b/test/core/generate_mipmaps_sampler2d.cpp
@@ -1,3 +1,9 @@
+/*
+ * Tests for loading texels and generating mipmaps (2-D textures + texture sampler)
+ */
+
+#include <vector>
+
 #include <gli/comparison.hpp>
 #include <gli/type.hpp>
 #include <gli/view.hpp>
@@ -9,139 +15,169 @@
 namespace generate_mipmaps
 {
 	template <typename genType>
-	int test(gli::format Format, genType const & Black, genType const & Color, std::size_t Size, gli::filter Filter)
+	int test(gli::format Format, const genType& BaseColor, const genType& TargetColor, std::size_t Size, gli::filter Filter)
 	{
 		int Error = 0;
 
-		gli::texture2d Texture(Format, gli::texture2d::extent_type(static_cast<gli::texture2d::extent_type::value_type>(Size)));
-		Texture.clear(Black);
-		Texture[0].clear(Color);
+		// create 2-D texture of appropriate size and clear with texels of given colors
+		gli::texture2d Texture(Format,
+			static_cast<gli::texture2d::extent_type>(static_cast<gli::texture2d::extent_type::value_type>(Size)));
+		Texture.clear(BaseColor);
+		Texture[0].clear(TargetColor);
 
-		genType const LoadC = Texture.load<genType>(gli::texture2d::extent_type(0), Texture.max_level());
-		if(Texture.levels() > 1)
-			Error += LoadC == Black ? 0 : 1;
+		// get texel at position #0 from top mipmap level
+		const genType TopTexel = Texture.load<genType>(static_cast<gli::texture2d::extent_type>(0),
+			Texture.max_level());
 
+		// If texture has multiple mipmap levels, texel from top level must match base color
+		if (Texture.levels() > 1)
+			Error += (TopTexel == BaseColor) ? 0 : 1;
+
+		// create a texture view and a sampler
 		gli::texture2d TextureView(gli::view(Texture, 0, 0));
 		gli::fsampler2D SamplerA(gli::texture2d(gli::duplicate(Texture)), gli::WRAP_CLAMP_TO_EDGE);
-		SamplerA.generate_mipmaps(gli::FILTER_LINEAR);
 
+		// generate mipmaps via filtering and get
+		SamplerA.generate_mipmaps(Filter);
 		gli::texture2d MipmapsA = SamplerA();
-		genType const LoadA = MipmapsA.load<genType>(gli::texture2d::extent_type(0), MipmapsA.max_level());
-		Error += LoadA == Color ? 0 : 1;
-		if(Texture.levels() > 1)
-			Error += LoadA != LoadC ? 0 : 1;
 
-		gli::texture2d MipmapViewA(gli::view(MipmapsA, 0, 0));
-		Error += TextureView == MipmapViewA ? 0 : 1;
+		// get texel at position #0 from top mipmap level (should match target color
+		const genType TopTexelA = MipmapsA.load<genType>(static_cast<gli::texture2d::extent_type>(0),
+			MipmapsA.max_level());
+		Error += (TopTexelA == TargetColor) ? 0 : 1;
+
+		// if texture has multiple mipmap levels, texel from top level can't match texel from original texture
+		if (Texture.levels() > 1)
+			Error += (TopTexelA != TopTexel) ? 0 : 1;
+
+		// create mipmaps view (should match texture view)
+		gli::texture2d MipmapsViewA(gli::view(MipmapsA, 0, 0));
+		Error += (TextureView == MipmapsViewA) ? 0 : 1;
 
 		// Mipmaps generation using the wrapper function
 		gli::texture2d MipmapsB = gli::generate_mipmaps(gli::texture2d(gli::duplicate(Texture)), Filter);
-		genType const LoadB = MipmapsB.load<genType>(gli::texture2d::extent_type(0), MipmapsB.max_level());
-		Error += LoadB == Color ? 0 : 1;
-		if(Texture.levels() > 1)
-			Error += LoadB != LoadC ? 0 : 1;
 
-		gli::texture2d MipmapViewB(gli::view(MipmapsB, 0, 0));
-		Error += TextureView == MipmapViewB ? 0 : 1;
+		// load texel at position #0 from top mipmap level (should match target color)
+		const genType TopTexelB = MipmapsB.load<genType>(static_cast<gli::texture2d::extent_type>(0),
+			MipmapsB.max_level());
+		Error += (TopTexelB == TargetColor) ? 0 : 1;
+
+		// if texture has multiple levels, texel from top level can't match texel from original texture
+		if (Texture.levels() > 1)
+			Error += (TopTexelB != TopTexel) ? 0 : 1;
+
+		// create mipmaps view and match against texture view
+		gli::texture2d MipmapsViewB(gli::view(MipmapsB, 0, 0));
+		Error += (TextureView == MipmapsViewB) ? 0 : 1;
 
 		// Compare custom mipmaps generation and wrapper mipmaps generation
-		Error += MipmapViewA == MipmapViewB ? 0 : 1;
-		Error += MipmapsA == MipmapsB ? 0 : 1;
+		Error += (MipmapsViewA == MipmapsViewB) ? 0 : 1;
+		Error += (MipmapsA == MipmapsB) ? 0 : 1;
 
 		return Error;
 	}
-}//namespace generate_mipmaps
+} //namespace generate_mipmaps
 
 int main()
 {
 	int Error = 0;
 
-	std::vector<gli::filter> Filters;
-	Filters.push_back(gli::FILTER_NEAREST);
-	Filters.push_back(gli::FILTER_LINEAR);
+	// select filters for mipmap generation
+	std::vector<gli::filter> Filters = {
+		gli::FILTER_NEAREST,
+		gli::FILTER_LINEAR
+	};
 
-	std::vector<gli::size_t> Sizes;
-	Sizes.push_back(1);
-	Sizes.push_back(2);
-	Sizes.push_back(3);
-	Sizes.push_back(15);
-	Sizes.push_back(16);
-	Sizes.push_back(17);
-	Sizes.push_back(24);
-	Sizes.push_back(32);
+	// select texture sizes
+	std::vector<gli::size_t> Sizes = { 1, 2, 3, 4, 8, 16, 17, 24, 28, 32, 64, 12 };
 
-	for(std::size_t FilterIndex = 0, FilterCount = Filters.size(); FilterIndex < FilterCount; ++FilterIndex)
-	for(std::size_t SizeIndex = 0, SizeCount = Sizes.size(); SizeIndex < SizeCount; ++SizeIndex)
-	{
-		Error += generate_mipmaps::test(gli::FORMAT_R16_SFLOAT_PACK16,
-			gli::packHalf(glm::vec1(0.0f)),
-			gli::packHalf(glm::vec1(1.0f)),
-			Sizes[SizeIndex], Filters[FilterIndex]);
+	// run tests for each filter and size
+	for (const auto Filter: Filters) {
+		for (const auto Size: Sizes) {
+			Error += generate_mipmaps::test(gli::FORMAT_R16_SFLOAT_PACK16,
+				gli::packHalf(glm::vec1(0.0f)),
+				gli::packHalf(glm::vec1(1.0f)),
+				Size,
+				Filter);
 
-		Error += generate_mipmaps::test(gli::FORMAT_RG16_SFLOAT_PACK16,
-			gli::packHalf(glm::vec2(0.0f, 0.0f)),
-			gli::packHalf(glm::vec2(1.0f, 0.5f)),
-			Sizes[SizeIndex], Filters[FilterIndex]);
+			Error += generate_mipmaps::test(gli::FORMAT_RG16_SFLOAT_PACK16,
+				gli::packHalf(glm::vec2(0.0f, 0.0f)),
+				gli::packHalf(glm::vec2(1.0f, 0.5f)),
+				Size,
+				Filter);
 
-		Error += generate_mipmaps::test(gli::FORMAT_RGB16_SFLOAT_PACK16,
-			gli::packHalf(glm::vec3(0.0f, 0.0f, 0.0f)),
-			gli::packHalf(glm::vec3(1.0f, 0.5f, 0.0f)),
-			Sizes[SizeIndex], Filters[FilterIndex]);
+			Error += generate_mipmaps::test(gli::FORMAT_RGB16_SFLOAT_PACK16,
+				gli::packHalf(glm::vec3(0.0f, 0.0f, 0.0f)),
+				gli::packHalf(glm::vec3(1.0f, 0.5f, 0.0f)),
+				Size,
+				Filter);
 
-		Error += generate_mipmaps::test(gli::FORMAT_RGBA16_SFLOAT_PACK16,
-			gli::packHalf(glm::vec4(0.0f, 0.0f, 0.0f, 0.0f)),
-			gli::packHalf(glm::vec4(1.0f, 0.5f, 0.0f, 1.0f)),
-			Sizes[SizeIndex], Filters[FilterIndex]);
+			Error += generate_mipmaps::test(gli::FORMAT_RGBA16_SFLOAT_PACK16,
+				gli::packHalf(glm::vec4(0.0f, 0.0f, 0.0f, 0.0f)),
+				gli::packHalf(glm::vec4(1.0f, 0.5f, 0.0f, 1.0f)),
+				Size,
+				Filter);
 
-		Error += generate_mipmaps::test(gli::FORMAT_R32_SFLOAT_PACK32,
-			glm::vec1(0.0f),
-			glm::vec1(1.0f),
-			Sizes[SizeIndex], Filters[FilterIndex]);
+			Error += generate_mipmaps::test(gli::FORMAT_R32_SFLOAT_PACK32,
+				glm::vec1(0.0f),
+				glm::vec1(1.0f),
+				Size,
+				Filter);
 
-		Error += generate_mipmaps::test(gli::FORMAT_RG32_SFLOAT_PACK32,
-			glm::vec2(0.0f, 0.0f),
-			glm::vec2(1.0f, 0.5f),
-			Sizes[SizeIndex], Filters[FilterIndex]);
+			Error += generate_mipmaps::test(gli::FORMAT_RG32_SFLOAT_PACK32,
+				glm::vec2(0.0f, 0.0f),
+				glm::vec2(1.0f, 0.5f),
+				Size,
+				Filter);
 
-		Error += generate_mipmaps::test(gli::FORMAT_RGB32_SFLOAT_PACK32,
-			glm::vec3(0.0f, 0.0f, 0.0f),
-			glm::vec3(1.0f, 0.5f, 0.0f),
-			Sizes[SizeIndex], Filters[FilterIndex]);
+			Error += generate_mipmaps::test(gli::FORMAT_RGB32_SFLOAT_PACK32,
+				glm::vec3(0.0f, 0.0f, 0.0f),
+				glm::vec3(1.0f, 0.5f, 0.0f),
+				Size,
+				Filter);
 
-		Error += generate_mipmaps::test(gli::FORMAT_RGBA32_SFLOAT_PACK32,
-			glm::vec4(0.0f, 0.0f, 0.0f, 0.0f),
-			glm::vec4(1.0f, 0.5f, 0.0f, 1.0f),
-			Sizes[SizeIndex], Filters[FilterIndex]);
+			Error += generate_mipmaps::test(gli::FORMAT_RGBA32_SFLOAT_PACK32,
+				glm::vec4(0.0f, 0.0f, 0.0f, 0.0f),
+				glm::vec4(1.0f, 0.5f, 0.0f, 1.0f),
+				Size,
+				Filter);
 
-		Error += generate_mipmaps::test(gli::FORMAT_RGBA4_UNORM_PACK16,
-			gli::packUnorm4x4(glm::vec4(0.0f, 0.0f, 0.0f, 0.0f)),
-			gli::packUnorm4x4(glm::vec4(1.0f, 0.5f, 0.0f, 1.0f)),
-			Sizes[SizeIndex], Filters[FilterIndex]);
+			Error += generate_mipmaps::test(gli::FORMAT_RGBA4_UNORM_PACK16,
+				gli::packUnorm4x4(glm::vec4(0.0f, 0.0f, 0.0f, 0.0f)),
+				gli::packUnorm4x4(glm::vec4(1.0f, 0.5f, 0.0f, 1.0f)),
+				Size,
+				Filter);
 
-		Error += generate_mipmaps::test(gli::FORMAT_RGBA8_UNORM_PACK8,
-			glm::u8vec4(0, 0, 0, 0),
-			glm::u8vec4(255, 127, 0, 255),
-			Sizes[SizeIndex], Filters[FilterIndex]);
+			Error += generate_mipmaps::test(gli::FORMAT_RGBA8_UNORM_PACK8,
+				glm::u8vec4(0, 0, 0, 0),
+				glm::u8vec4(255, 127, 0, 255),
+				Size,
+				Filter);
 
-		Error += generate_mipmaps::test(gli::FORMAT_RGBA8_SNORM_PACK8,
-			glm::i8vec4(0, 0, 0, 0),
-			glm::i8vec4(127, 63, 0, 1),
-			Sizes[SizeIndex], Filters[FilterIndex]);
+			Error += generate_mipmaps::test(gli::FORMAT_RGBA8_SNORM_PACK8,
+				glm::i8vec4(0, 0, 0, 0),
+				glm::i8vec4(127, 63, 0, 1),
+				Size,
+				Filter);
 
-		Error += generate_mipmaps::test(gli::FORMAT_RGB10A2_UNORM_PACK32,
-			gli::packUnorm3x10_1x2(glm::vec4(0.0f, 0.0f, 0.0f, 0.0f)),
-			gli::packUnorm3x10_1x2(glm::vec4(1.0f, 0.5f, 0.0f, 1.0f)),
-			Sizes[SizeIndex], Filters[FilterIndex]);
+			Error += generate_mipmaps::test(gli::FORMAT_RGB10A2_UNORM_PACK32,
+				gli::packUnorm3x10_1x2(glm::vec4(0.0f, 0.0f, 0.0f, 0.0f)),
+				gli::packUnorm3x10_1x2(glm::vec4(1.0f, 0.5f, 0.0f, 1.0f)),
+				Size,
+				Filter);
 
-		Error += generate_mipmaps::test(gli::FORMAT_RGB10A2_SNORM_PACK32,
-			gli::packSnorm3x10_1x2(glm::vec4(0.0f, 0.0f, 0.0f, 0.0f)),
-			gli::packSnorm3x10_1x2(glm::vec4(1.0f, 0.5f, 0.0f, 1.0f)),
-			Sizes[SizeIndex], Filters[FilterIndex]);
+			Error += generate_mipmaps::test(gli::FORMAT_RGB10A2_SNORM_PACK32,
+				gli::packSnorm3x10_1x2(glm::vec4(0.0f, 0.0f, 0.0f, 0.0f)),
+				gli::packSnorm3x10_1x2(glm::vec4(1.0f, 0.5f, 0.0f, 1.0f)),
+				Size,
+				Filter);
 
-		Error += generate_mipmaps::test(gli::FORMAT_RGB9E5_UFLOAT_PACK32,
-			gli::packF3x9_E1x5(glm::vec3(0.0f, 0.0f, 0.0f)),
-			gli::packF3x9_E1x5(glm::vec3(1.0f, 0.5f, 0.0f)),
-			Sizes[SizeIndex], Filters[FilterIndex]);
+			Error += generate_mipmaps::test(gli::FORMAT_RGB9E5_UFLOAT_PACK32,
+				gli::packF3x9_E1x5(glm::vec3(0.0f, 0.0f, 0.0f)),
+				gli::packF3x9_E1x5(glm::vec3(1.0f, 0.5f, 0.0f)),
+				Size,
+				Filter);
+		}
 	}
 
 	return Error;


### PR DESCRIPTION
Currently, 2 test groups are failing:
```
Running tests...
Test project /home/amender/projects/gli/build
      Start  1: test-bug
 1/70 Test  #1: test-bug ...................................   Passed    0.00 sec
      Start  2: test-core
 2/70 Test  #2: test-core ..................................   Passed    0.14 sec
      Start  3: test-core_addressing
 3/70 Test  #3: test-core_addressing .......................   Passed    0.00 sec
      Start  4: test-core_comparison
 4/70 Test  #4: test-core_comparison .......................   Passed    0.00 sec
      Start  5: test-convert_sampler1d
 5/70 Test  #5: test-convert_sampler1d .....................   Passed    0.00 sec
      Start  6: test-convert_sampler1d_array
 6/70 Test  #6: test-convert_sampler1d_array ...............   Passed    0.00 sec
      Start  7: test-convert_sampler2d
 7/70 Test  #7: test-convert_sampler2d .....................   Passed    0.00 sec
      Start  8: test-convert_sampler2d_array
 8/70 Test  #8: test-convert_sampler2d_array ...............   Passed    0.00 sec
      Start  9: test-convert_sampler3d
 9/70 Test  #9: test-convert_sampler3d .....................   Passed    0.00 sec
      Start 10: test-convert_sampler_cube
10/70 Test #10: test-convert_sampler_cube ..................   Passed    0.00 sec
      Start 11: test-convert_sampler_cube_array
11/70 Test #11: test-convert_sampler_cube_array ............   Passed    0.00 sec
      Start 12: test-core_convert
12/70 Test #12: test-core_convert ..........................   Passed    0.43 sec
      Start 13: test-core_convert_access
13/70 Test #13: test-core_convert_access ...................   Passed    0.00 sec
      Start 14: test-core_filter_1d
14/70 Test #14: test-core_filter_1d ........................   Passed    0.00 sec
      Start 15: test-core_filter_2d
15/70 Test #15: test-core_filter_2d ........................   Passed    0.00 sec
      Start 16: test-core_filter_3d
16/70 Test #16: test-core_filter_3d ........................   Passed    0.00 sec
      Start 17: test-core_format
17/70 Test #17: test-core_format ...........................   Passed    0.00 sec
      Start 18: test-core_sample
18/70 Test #18: test-core_sample ...........................   Passed    0.00 sec
      Start 19: test-core_storage
19/70 Test #19: test-core_storage ..........................   Passed    0.00 sec
      Start 20: test-core_image
20/70 Test #20: test-core_image ............................   Passed    0.00 sec
      Start 21: test-core_load
21/70 Test #21: test-core_load .............................   Passed    0.02 sec
      Start 22: test-core_load_gen_1d
22/70 Test #22: test-core_load_gen_1d ......................   Passed    0.08 sec
      Start 23: test-core_load_gen_1d_array
23/70 Test #23: test-core_load_gen_1d_array ................   Passed    0.04 sec
      Start 24: test-core_load_gen_2d
24/70 Test #24: test-core_load_gen_2d ......................   Passed    0.05 sec
      Start 25: test-core_load_gen_2d_array
25/70 Test #25: test-core_load_gen_2d_array ................   Passed    0.05 sec
      Start 26: test-core_load_gen_3d
26/70 Test #26: test-core_load_gen_3d ......................   Passed    0.03 sec
      Start 27: test-core_load_gen_cube
27/70 Test #27: test-core_load_gen_cube ....................   Passed    0.06 sec
      Start 28: test-core_load_gen_cube_array
28/70 Test #28: test-core_load_gen_cube_array ..............   Passed    0.08 sec
      Start 29: test-core_load_gen_rect
29/70 Test #29: test-core_load_gen_rect ....................   Passed    0.04 sec
      Start 30: test-core_load_dds
30/70 Test #30: test-core_load_dds .........................   Passed    0.02 sec
      Start 31: test-core_load_ktx
31/70 Test #31: test-core_load_ktx .........................   Passed    0.06 sec
      Start 32: test-core_sampler_clear
32/70 Test #32: test-core_sampler_clear ....................   Passed    0.00 sec
      Start 33: test-core_sampler_texel
33/70 Test #33: test-core_sampler_texel ....................   Passed    0.00 sec
      Start 34: test-core_sampler_wrap
34/70 Test #34: test-core_sampler_wrap .....................   Passed    0.00 sec
      Start 35: test-core_save
35/70 Test #35: test-core_save .............................   Passed    0.00 sec
      Start 36: test-gl
36/70 Test #36: test-gl ....................................   Passed    0.00 sec
      Start 37: test-texture_lod_sampler1d
37/70 Test #37: test-texture_lod_sampler1d .................   Passed    0.00 sec
      Start 38: test-texture_lod_sampler1d_array
38/70 Test #38: test-texture_lod_sampler1d_array ...........   Passed    0.00 sec
      Start 39: test-texture_lod_sampler2d
39/70 Test #39: test-texture_lod_sampler2d .................   Passed    0.00 sec
      Start 40: test-texture_lod_sampler2d_array
40/70 Test #40: test-texture_lod_sampler2d_array ...........   Passed    0.00 sec
      Start 41: test-texture_lod_sampler3d
41/70 Test #41: test-texture_lod_sampler3d .................   Passed    0.00 sec
      Start 42: test-texture_lod_sampler_cube
42/70 Test #42: test-texture_lod_sampler_cube ..............   Passed    0.00 sec
      Start 43: test-texture_lod_sampler_cube_array
43/70 Test #43: test-texture_lod_sampler_cube_array ........   Passed    0.00 sec
      Start 44: test-generate_mipmaps_sampler1d
44/70 Test #44: test-generate_mipmaps_sampler1d ............***Failed    0.03 sec
      Start 45: test-generate_mipmaps_sampler1d_array
45/70 Test #45: test-generate_mipmaps_sampler1d_array ......   Passed    0.50 sec
      Start 46: test-generate_mipmaps_sampler2d
46/70 Test #46: test-generate_mipmaps_sampler2d ............***Failed    0.14 sec
      Start 47: test-generate_mipmaps_sampler2d_array
47/70 Test #47: test-generate_mipmaps_sampler2d_array ......   Passed    1.20 sec
      Start 48: test-generate_mipmaps_sampler3d
48/70 Test #48: test-generate_mipmaps_sampler3d ............   Passed    0.44 sec
      Start 49: test-generate_mipmaps_sampler_cube
49/70 Test #49: test-generate_mipmaps_sampler_cube .........   Passed    1.41 sec
      Start 50: test-generate_mipmaps_sampler_cube_array
50/70 Test #50: test-generate_mipmaps_sampler_cube_array ...   Passed    1.93 sec
      Start 51: test-core_swizzle
51/70 Test #51: test-core_swizzle ..........................   Passed    0.00 sec
      Start 52: test-core_texture
52/70 Test #52: test-core_texture ..........................   Passed    9.06 sec
      Start 53: test-core_texture_1d
53/70 Test #53: test-core_texture_1d .......................   Passed    0.00 sec
      Start 54: test-core_texture_1d_array
54/70 Test #54: test-core_texture_1d_array .................   Passed    0.01 sec
      Start 55: test-core_texture_2d
55/70 Test #55: test-core_texture_2d .......................   Passed    0.02 sec
      Start 56: test-core_texture_2d_array
56/70 Test #56: test-core_texture_2d_array .................   Passed    0.01 sec
      Start 57: test-core_texture_3d
57/70 Test #57: test-core_texture_3d .......................   Passed    0.01 sec
      Start 58: test-core_texture_cube
58/70 Test #58: test-core_texture_cube .....................   Passed    0.01 sec
      Start 59: test-core_texture_cube_array
59/70 Test #59: test-core_texture_cube_array ...............   Passed    0.01 sec
      Start 60: test-core_clear
60/70 Test #60: test-core_clear ............................   Passed    0.04 sec
      Start 61: test-core_fetch
61/70 Test #61: test-core_fetch ............................   Passed    0.00 sec
      Start 62: test-core_flip
62/70 Test #62: test-core_flip .............................   Passed    0.01 sec
      Start 63: test-reduce
63/70 Test #63: test-reduce ................................   Passed    0.07 sec
      Start 64: test-test_copy
64/70 Test #64: test-test_copy .............................   Passed    0.01 sec
      Start 65: test-test_copy_sub
65/70 Test #65: test-test_copy_sub .........................   Passed    0.00 sec
      Start 66: test-test_duplicate
66/70 Test #66: test-test_duplicate ........................   Passed    0.08 sec
      Start 67: test-test_view
67/70 Test #67: test-test_view .............................   Passed    0.05 sec
      Start 68: test-test_size
68/70 Test #68: test-test_size .............................   Passed    0.00 sec
      Start 69: test-test_make_texture
69/70 Test #69: test-test_make_texture .....................   Passed    0.00 sec
      Start 70: test-transform
70/70 Test #70: test-transform .............................   Passed    0.00 sec

97% tests passed, 2 tests failed out of 70

Total Test time (real) =  16.21 sec

The following tests FAILED:
         44 - test-generate_mipmaps_sampler1d (Failed)
         46 - test-generate_mipmaps_sampler2d (Failed)
Errors while running CTest
make: *** [Makefile:150: test] Error 8
```

This PR will address the root cause - either the test cases or the underlying functions.