### PR TITLE
Fix compiler errors and warnings

### DIFF
--- a/test/core/core_convert.cpp
+++ b/test/core/core_convert.cpp
@@ -1,3 +1,6 @@
+#include <ctime>
+#include <string>
+
 #include <gli/load.hpp>
 #include <gli/save.hpp>
 #include <gli/convert.hpp>
@@ -6,40 +9,44 @@
 #include <gli/core/s3tc.hpp>
 #include <gli/texture2d.hpp>
 #include <gli/generate_mipmaps.hpp>
+
 #include <glm/gtc/epsilon.hpp>
 #include <glm/gtx/vec_swizzle.hpp>
-#include <ctime>
 
-namespace
-{
-	std::string path(const char* filename)
-	{
+namespace {
+	// TODO: use ``const std::string&` filename instead?
+	/*
+	 * Get full to path to data file from `filename`.
+	 */
+	std::string path(const char* filename) {
+		// TODO: SOURCE_DIR defined where?
 		return std::string(SOURCE_DIR) + "/data/" + filename;
 	}
 
-	struct params
-	{
-		params(std::string const & Filename, gli::format Format)
-			: Filename(Filename)
-			, Format(Format)
-		{}
+	struct params {
+		params(const std::string& Filename, gli::format Format)
+			: Filename(Filename), Format(Format) {}
 
 		std::string Filename;
 		gli::format Format;
 	};
-}//namespace
+} // namespace
 
-bool convert_rgb32f_rgb9e5(const char* FilenameSrc, const char* FilenameDst)
-{
-	if(FilenameDst == NULL)
+// TODO use `const std::string& instead?`
+bool convert_rgb32f_rgb9e5(const char* FilenameSrc, const char* FilenameDst) {
+	if (FilenameDst == nullptr)
 		return false;
-	if(std::strstr(FilenameDst, ".dds") > 0 || std::strstr(FilenameDst, ".ktx") > 0)
+
+	// TOOO: use the C++ std::string::find instead?
+	if (std::strstr(FilenameDst, ".dds") != nullptr || std::strstr(FilenameDst, ".ktx") != nullptr)
 		return false;
 
 	gli::texture2d TextureSource(gli::load(FilenameSrc));
-	if(TextureSource.empty())
+
+	if (TextureSource.empty())
 		return false;
-	if(TextureSource.format() != gli::FORMAT_RGB16_SFLOAT_PACK16 && TextureSource.format() != gli::FORMAT_RGB32_SFLOAT_PACK32)
+
+	if (TextureSource.format() != gli::FORMAT_RGB16_SFLOAT_PACK16 && TextureSource.format() != gli::FORMAT_RGB32_SFLOAT_PACK32)
 		return false;
 
 	gli::texture2d TextureMipmaped = gli::generate_mipmaps(TextureSource, gli::FILTER_LINEAR);
@@ -50,11 +57,9 @@ bool convert_rgb32f_rgb9e5(const char* FilenameSrc, const char* FilenameDst)
 	return true;
 }
 
-namespace r8unorm
-{
-	int test()
-	{
-		int Error(0);
+namespace r8unorm {
+	int test() {
+		int Error = 0;
 
 		gli::texture2d A(gli::FORMAT_R8_UNORM_PACK8, gli::extent2d(2), 1);
 		A.store(gli::extent2d(0, 0), 0, glm::u8vec1(192));
@@ -62,27 +67,25 @@ namespace r8unorm
 		A.store(gli::extent2d(1, 1), 0, glm::u8vec1(0));
 		A.store(gli::extent2d(0, 1), 0, glm::u8vec1(16));
 
-		gli::texture2d const B = gli::convert(A, gli::FORMAT_RGBA8_UNORM_PACK8);
-		gli::texture2d const C = gli::convert(B, gli::FORMAT_R8_UNORM_PACK8);
-		Error += A == C ? 0 : 1;
+		const gli::texture2d B = gli::convert(A, gli::FORMAT_RGBA8_UNORM_PACK8);
+		const gli::texture2d C = gli::convert(B, gli::FORMAT_R8_UNORM_PACK8);
+		Error += (A == C) ? 0 : 1;
 
-		gli::texture2d const D = gli::convert(A, gli::FORMAT_RGB8_UNORM_PACK8);
-		gli::texture2d const E = gli::convert(D, gli::FORMAT_R8_UNORM_PACK8);
-		Error += A == E ? 0 : 1;
+		const gli::texture2d D = gli::convert(A, gli::FORMAT_RGB8_UNORM_PACK8);
+		const gli::texture2d E = gli::convert(D, gli::FORMAT_R8_UNORM_PACK8);
+		Error += (A == E) ? 0 : 1;
 
-		gli::texture2d const F = gli::convert(A, gli::FORMAT_RG8_UNORM_PACK8);
-		gli::texture2d const G = gli::convert(F, gli::FORMAT_R8_UNORM_PACK8);
-		Error += A == G ? 0 : 1;
+		const gli::texture2d F = gli::convert(A, gli::FORMAT_RG8_UNORM_PACK8);
+		const gli::texture2d G = gli::convert(F, gli::FORMAT_R8_UNORM_PACK8);
+		Error += (A == G) ? 0 : 1;
 
 		return Error;
 	}
-}//namespace r8unorm
+} // namespace r8unorm
 
-namespace rg8unorm
-{
-	int test()
-	{
-		int Error(0);
+namespace rg8unorm {
+	int test() {
+		int Error = 0;
 
 		gli::texture2d A(gli::FORMAT_RG8_UNORM_PACK8, gli::extent2d(2), 1);
 		A.store(gli::extent2d(0, 0), 0, glm::u8vec2(192, 48));
@@ -90,23 +93,21 @@ namespace rg8unorm
 		A.store(gli::extent2d(1, 1), 0, glm::u8vec2(0, 128));
 		A.store(gli::extent2d(0, 1), 0, glm::u8vec2(16, 48));
 
-		gli::texture2d const B = gli::convert(A, gli::FORMAT_RGBA8_UNORM_PACK8);
-		gli::texture2d const C = gli::convert(B, gli::FORMAT_RG8_UNORM_PACK8);
-		Error += A == C ? 0 : 1;
+		const gli::texture2d B = gli::convert(A, gli::FORMAT_RGBA8_UNORM_PACK8);
+		const gli::texture2d C = gli::convert(B, gli::FORMAT_RG8_UNORM_PACK8);
+		Error += (A == C) ? 0 : 1;
 
-		gli::texture2d const D = gli::convert(A, gli::FORMAT_RGB8_UNORM_PACK8);
-		gli::texture2d const E = gli::convert(D, gli::FORMAT_RG8_UNORM_PACK8);
-		Error += A == E ? 0 : 1;
+		const gli::texture2d D = gli::convert(A, gli::FORMAT_RGB8_UNORM_PACK8);
+		const gli::texture2d E = gli::convert(D, gli::FORMAT_RG8_UNORM_PACK8);
+		Error += (A == E) ? 0 : 1;
 
 		return Error;
 	}
-}//namespace rg8unorm
+} // namespace rg8unorm
 
-namespace rgb8unorm
-{
-	int test()
-	{
-		int Error(0);
+namespace rgb8unorm {
+	int test() {
+		int Error = 0;
 
 		gli::texture2d A(gli::FORMAT_RGB8_UNORM_PACK8, gli::extent2d(2), 1);
 		A.store(gli::extent2d(0, 0), 0, glm::u8vec3(192, 48, 16));
@@ -114,20 +115,18 @@ namespace rgb8unorm
 		A.store(gli::extent2d(1, 1), 0, glm::u8vec3(0, 128, 255));
 		A.store(gli::extent2d(0, 1), 0, glm::u8vec3(16, 48, 192));
 
-		gli::texture2d const B = gli::convert(A, gli::FORMAT_RGBA8_UNORM_PACK8);
-		gli::texture2d const C = gli::convert(B, gli::FORMAT_RGB8_UNORM_PACK8);
+		const gli::texture2d B = gli::convert(A, gli::FORMAT_RGBA8_UNORM_PACK8);
+		const gli::texture2d C = gli::convert(B, gli::FORMAT_RGB8_UNORM_PACK8);
 
-		Error += A == C ? 0 : 1;
+		Error += (A == C) ? 0 : 1;
 
 		return Error;
 	}
-}//namespace rgb8unorm
+} // namespace rgb8unorm
 
-namespace r16unorm
-{
-	int test()
-	{
-		int Error(0);
+namespace r16unorm {
+	int test() {
+		int Error = 0;
 
 		gli::texture2d A(gli::FORMAT_R16_UNORM_PACK16, gli::extent2d(2), 1);
 		A.store(gli::extent2d(0, 0), 0, glm::u16vec1(0x7777));
@@ -135,20 +134,18 @@ namespace r16unorm
 		A.store(gli::extent2d(1, 1), 0, glm::u16vec1(0x5555));
 		A.store(gli::extent2d(0, 1), 0, glm::u16vec1(0x3333));
 
-		gli::texture2d const B = gli::convert(A, gli::FORMAT_RGBA16_UNORM_PACK16);
-		gli::texture2d const C = gli::convert(B, gli::FORMAT_R16_UNORM_PACK16);
+		const gli::texture2d B = gli::convert(A, gli::FORMAT_RGBA16_UNORM_PACK16);
+		const gli::texture2d C = gli::convert(B, gli::FORMAT_R16_UNORM_PACK16);
 
-		Error += A == C ? 0 : 1;
+		Error += (A == C) ? 0 : 1;
 
 		return Error;
 	}
-}//namespace r16unorm
+} // namespace r16unorm
 
-namespace rg16unorm
-{
-	int test()
-	{
-		int Error(0);
+namespace rg16unorm {
+	int test() {
+		int Error = 0;
 
 		gli::texture2d A(gli::FORMAT_RG16_UNORM_PACK16, gli::extent2d(2), 1);
 		A.store(gli::extent2d(0, 0), 0, glm::u16vec2(0x7777, 0x5555));
@@ -156,20 +153,18 @@ namespace rg16unorm
 		A.store(gli::extent2d(1, 1), 0, glm::u16vec2(0x5555, 0x2222));
 		A.store(gli::extent2d(0, 1), 0, glm::u16vec2(0xaaaa, 0xcccc));
 
-		gli::texture2d const B = gli::convert(A, gli::FORMAT_RGBA16_UNORM_PACK16);
-		gli::texture2d const C = gli::convert(B, gli::FORMAT_RG16_UNORM_PACK16);
+		const gli::texture2d B = gli::convert(A, gli::FORMAT_RGBA16_UNORM_PACK16);
+		const gli::texture2d C = gli::convert(B, gli::FORMAT_RG16_UNORM_PACK16);
 
-		Error += A == C ? 0 : 1;
+		Error += (A == C) ? 0 : 1;
 
 		return Error;
 	}
-}//namespace rg16unorm
+} // namespace rg16unorm
 
-namespace rgb16unorm
-{
-	int test()
-	{
-		int Error(0);
+namespace rgb16unorm {
+	int test() {
+		int Error = 0;
 
 		gli::texture2d A(gli::FORMAT_RGB16_UNORM_PACK16, gli::extent2d(2), 1);
 		A.store(gli::extent2d(0, 0), 0, glm::u16vec3(0x7777, 0x5555, 0x3333));
@@ -177,19 +172,17 @@ namespace rgb16unorm
 		A.store(gli::extent2d(1, 1), 0, glm::u16vec3(0x5555, 0x2222, 0xbbbb));
 		A.store(gli::extent2d(0, 1), 0, glm::u16vec3(0xaaaa, 0xcccc, 0xeeee));
 
-		gli::texture2d const B = gli::convert(A, gli::FORMAT_RGBA16_UNORM_PACK16);
-		gli::texture2d const C = gli::convert(B, gli::FORMAT_RGB16_UNORM_PACK16);
+		const gli::texture2d B = gli::convert(A, gli::FORMAT_RGBA16_UNORM_PACK16);
+		const gli::texture2d C = gli::convert(B, gli::FORMAT_RGB16_UNORM_PACK16);
 
-		Error += A == C ? 0 : 1;
+		Error += (A == C) ? 0 : 1;
 
 		return Error;
 	}
-}//namespace rgb16unorm
+} // namespace rgb16unorm
 
-namespace rgb10a2norm
-{
-	int test()
-	{
+namespace rgb10a2norm {
+	int test() {
 		int Error = 0;
 
 		{
@@ -198,7 +191,7 @@ namespace rgb10a2norm
 
 			gli::texture1d TextureDst = gli::convert(TextureSrc, gli::FORMAT_RGB10A2_UNORM_PACK32);
 
-			Error += TextureSrc == TextureDst ? 0 : 1;
+			Error += (TextureSrc == TextureDst) ? 0 : 1;
 		}
 
 		{
@@ -207,7 +200,7 @@ namespace rgb10a2norm
 
 			gli::texture1d_array TextureDst = gli::convert(TextureSrc, gli::FORMAT_RGB10A2_UNORM_PACK32);
 
-			Error += TextureSrc == TextureDst ? 0 : 1;
+			Error += (TextureSrc == TextureDst) ? 0 : 1;
 		}
 
 		{
@@ -216,7 +209,7 @@ namespace rgb10a2norm
 
 			gli::texture2d TextureDst = gli::convert(TextureSrc, gli::FORMAT_RGB10A2_UNORM_PACK32);
 
-			Error += TextureSrc == TextureDst ? 0 : 1;
+			Error += (TextureSrc == TextureDst) ? 0 : 1;
 		}
 
 		{
@@ -225,7 +218,7 @@ namespace rgb10a2norm
 
 			gli::texture2d_array TextureDst = gli::convert(TextureSrc, gli::FORMAT_RGB10A2_UNORM_PACK32);
 
-			Error += TextureSrc == TextureDst ? 0 : 1;
+			Error += (TextureSrc == TextureDst) ? 0 : 1;
 		}
 
 		{
@@ -234,7 +227,7 @@ namespace rgb10a2norm
 
 			gli::texture3d TextureDst = gli::convert(TextureSrc, gli::FORMAT_RGB10A2_UNORM_PACK32);
 
-			Error += TextureSrc == TextureDst ? 0 : 1;
+			Error += (TextureSrc == TextureDst) ? 0 : 1;
 		}
 
 		{
@@ -243,7 +236,7 @@ namespace rgb10a2norm
 
 			gli::texture_cube TextureDst = gli::convert(TextureSrc, gli::FORMAT_RGB10A2_UNORM_PACK32);
 
-			Error += TextureSrc == TextureDst ? 0 : 1;
+			Error += (TextureSrc == TextureDst) ? 0 : 1;
 		}
 
 		{
@@ -252,17 +245,15 @@ namespace rgb10a2norm
 
 			gli::texture_cube_array TextureDst = gli::convert(TextureSrc, gli::FORMAT_RGB10A2_UNORM_PACK32);
 
-			Error += TextureSrc == TextureDst ? 0 : 1;
+			Error += (TextureSrc == TextureDst) ? 0 : 1;
 		}
 
 		return Error;
 	}
-}//namespace rgb10a2norm
+} // namespace rgb10a2norm
 
-namespace rgba_dxt1unorm
-{
-	int test()
-	{
+namespace rgba_dxt1unorm {
+	int test() {
 		gli::texture2d TextureCompressed(gli::load(path("kueken7_rgba_dxt1_unorm.dds")));
 		GLI_ASSERT(!TextureCompressed.empty());
 
@@ -272,7 +263,10 @@ namespace rgba_dxt1unorm
 		GLI_ASSERT(TextureCompressed.extent() == TextureDecompressed.extent());
 		GLI_ASSERT(TextureCompressed.levels() == TextureDecompressed.levels());
 
-		gli::texture2d TextureLocalDecompressed(TextureDecompressed.format(), TextureDecompressed.extent(), TextureDecompressed.levels(), TextureDecompressed.swizzles());
+		gli::texture2d TextureLocalDecompressed(TextureDecompressed.format(),
+				TextureDecompressed.extent(),
+				TextureDecompressed.levels(),
+				TextureDecompressed.swizzles());
 
 		GLI_ASSERT(sizeof(gli::detail::dxt1_block) == gli::block_size(gli::FORMAT_RGBA_DXT1_UNORM_BLOCK8));
 
@@ -284,24 +278,19 @@ namespace rgba_dxt1unorm
 			BlockExtent.y = TempExtent.y;
 		}
 
-		for(size_t Level = 0; Level < TextureCompressed.levels(); ++Level)
-		{
+		for (size_t Level = 0; Level < TextureCompressed.levels(); ++Level) {
 			gli::extent2d TexelCoord;
 			gli::extent2d BlockCoord;
 			gli::extent2d LevelExtent = TextureCompressed.extent(Level);
 			gli::extent2d LevelExtentInBlocks = glm::max(gli::extent2d(1, 1), LevelExtent / BlockExtent);
-			for(BlockCoord.y = 0, TexelCoord.y = 0; BlockCoord.y < LevelExtentInBlocks.y; ++BlockCoord.y, TexelCoord.y += BlockExtent.y)
-			{
-				for(BlockCoord.x = 0, TexelCoord.x = 0; BlockCoord.x < LevelExtentInBlocks.x; ++BlockCoord.x, TexelCoord.x += BlockExtent.x)
-				{
+			for (BlockCoord.y = 0, TexelCoord.y = 0; BlockCoord.y < LevelExtentInBlocks.y; ++BlockCoord.y, TexelCoord.y += BlockExtent.y) {
+				for (BlockCoord.x = 0, TexelCoord.x = 0; BlockCoord.x < LevelExtentInBlocks.x; ++BlockCoord.x, TexelCoord.x += BlockExtent.x) {
 					const gli::detail::dxt1_block *DXT1Block = TextureCompressed.data<gli::detail::dxt1_block>(0, 0, Level) + (BlockCoord.y * LevelExtentInBlocks.x + BlockCoord.x);
 					const gli::detail::texel_block4x4 DecompressedBlock = gli::detail::decompress_dxt1_block(*DXT1Block);
 
 					gli::extent2d DecompressedBlockCoord;
-					for(DecompressedBlockCoord.y = 0; DecompressedBlockCoord.y < glm::min(4, LevelExtent.y); ++DecompressedBlockCoord.y)
-					{
-						for(DecompressedBlockCoord.x = 0; DecompressedBlockCoord.x < glm::min(4, LevelExtent.x); ++DecompressedBlockCoord.x)
-						{
+					for (DecompressedBlockCoord.y = 0; DecompressedBlockCoord.y < glm::min(4, LevelExtent.y); ++DecompressedBlockCoord.y) {
+						for (DecompressedBlockCoord.x = 0; DecompressedBlockCoord.x < glm::min(4, LevelExtent.x); ++DecompressedBlockCoord.x) {
 							TextureLocalDecompressed.store(TexelCoord + DecompressedBlockCoord, Level, glm::u8vec4(glm::round(DecompressedBlock.Texel[DecompressedBlockCoord.y][DecompressedBlockCoord.x] * 255.0f)));
 						}
 					}
@@ -309,20 +298,17 @@ namespace rgba_dxt1unorm
 			}
 		}
 
-		int Error(0);
+		int Error = 0;
 
 		Error += (TextureDecompressed == TextureLocalDecompressed) ? 0 : 1;
 		
 		// Test converting through the convertFunc interface
 		// sampling at the corners of each level
-		for(int Level = 0; Level < TextureDecompressed.levels(); ++Level)
-		{
+		for (int Level = 0; Level < TextureDecompressed.levels(); ++Level) {
 			gli::extent2d TexelCoord;
 			gli::extent2d LevelExtent = TextureDecompressed.extent(Level);
-			for(TexelCoord.y = 0; TexelCoord.y < LevelExtent.y; TexelCoord.y += glm::max(1, LevelExtent.y - 1))
-			{
-				for(TexelCoord.x = 0; TexelCoord.x < LevelExtent.x; TexelCoord.x += glm::max(1, LevelExtent.x - 1))
-				{
+			for (TexelCoord.y = 0; TexelCoord.y < LevelExtent.y; TexelCoord.y += glm::max(1, LevelExtent.y - 1)) {
+				for (TexelCoord.x = 0; TexelCoord.x < LevelExtent.x; TexelCoord.x += glm::max(1, LevelExtent.x - 1)) {
 					glm::u8vec4 ColorFromCompressed = glm::u8vec4(glm::round(gli::detail::convertFunc<gli::texture2d, float, 4, std::uint8_t, glm::defaultp, gli::detail::CONVERT_MODE_DXT1UNORM, true>::fetch(TextureCompressed, TexelCoord, 0, 0, Level) * 255.0f));
 					glm::u8vec4 ColorFromDecompressed = TextureDecompressed.load<glm::u8vec4>(TexelCoord, Level);
 
@@ -333,12 +319,10 @@ namespace rgba_dxt1unorm
 
 		return Error;
 	}
-}//namespace rgba_dxt1unorm
+} // namespace rgba_dxt1unorm
 
-namespace rgba_dxt3unorm
-{
-	int test()
-	{
+namespace rgba_dxt3unorm {
+	int test() {
 		gli::texture2d TextureCompressed(gli::load(path("kueken7_rgba_dxt3_unorm.dds")));
 		GLI_ASSERT(!TextureCompressed.empty());
 
@@ -348,7 +332,10 @@ namespace rgba_dxt3unorm
 		GLI_ASSERT(TextureCompressed.extent() == TextureDecompressed.extent());
 		GLI_ASSERT(TextureCompressed.levels() == TextureDecompressed.levels());
 
-		gli::texture2d TextureLocalDecompressed(TextureDecompressed.format(), TextureDecompressed.extent(), TextureDecompressed.levels(), TextureDecompressed.swizzles());
+		gli::texture2d TextureLocalDecompressed(TextureDecompressed.format(),
+				TextureDecompressed.extent(),
+				TextureDecompressed.levels(),
+				TextureDecompressed.swizzles());
 
 		GLI_ASSERT(sizeof(gli::detail::dxt3_block) == gli::block_size(gli::FORMAT_RGBA_DXT3_UNORM_BLOCK16));
 
@@ -360,24 +347,19 @@ namespace rgba_dxt3unorm
 			BlockExtent.y = TempExtent.y;
 		}
 
-		for(size_t Level = 0; Level < TextureCompressed.levels(); ++Level)
-		{
+		for (size_t Level = 0; Level < TextureCompressed.levels(); ++Level) {
 			gli::extent2d TexelCoord;
 			gli::extent2d BlockCoord;
 			gli::extent2d LevelExtent = TextureCompressed.extent(Level);
 			gli::extent2d LevelExtentInBlocks = glm::max(gli::extent2d(1, 1), LevelExtent / BlockExtent);
-			for(BlockCoord.y = 0, TexelCoord.y = 0; BlockCoord.y < LevelExtentInBlocks.y; ++BlockCoord.y, TexelCoord.y += BlockExtent.y)
-			{
-				for(BlockCoord.x = 0, TexelCoord.x = 0; BlockCoord.x < LevelExtentInBlocks.x; ++BlockCoord.x, TexelCoord.x += BlockExtent.x)
-				{
+			for (BlockCoord.y = 0, TexelCoord.y = 0; BlockCoord.y < LevelExtentInBlocks.y; ++BlockCoord.y, TexelCoord.y += BlockExtent.y) {
+				for(BlockCoord.x = 0, TexelCoord.x = 0; BlockCoord.x < LevelExtentInBlocks.x; ++BlockCoord.x, TexelCoord.x += BlockExtent.x) {
 					const gli::detail::dxt3_block *DXT3Block = TextureCompressed.data<gli::detail::dxt3_block>(0, 0, Level) + (BlockCoord.y * LevelExtentInBlocks.x + BlockCoord.x);
 					const gli::detail::texel_block4x4 DecompressedBlock = gli::detail::decompress_dxt3_block(*DXT3Block);
 
 					gli::extent2d DecompressedBlockCoord;
-					for(DecompressedBlockCoord.y = 0; DecompressedBlockCoord.y < glm::min(4, LevelExtent.y); ++DecompressedBlockCoord.y)
-					{
-						for(DecompressedBlockCoord.x = 0; DecompressedBlockCoord.x < glm::min(4, LevelExtent.x); ++DecompressedBlockCoord.x)
-						{
+					for (DecompressedBlockCoord.y = 0; DecompressedBlockCoord.y < glm::min(4, LevelExtent.y); ++DecompressedBlockCoord.y) {
+						for (DecompressedBlockCoord.x = 0; DecompressedBlockCoord.x < glm::min(4, LevelExtent.x); ++DecompressedBlockCoord.x) {
 							TextureLocalDecompressed.store(TexelCoord + DecompressedBlockCoord, Level, glm::u8vec4(glm::round(DecompressedBlock.Texel[DecompressedBlockCoord.y][DecompressedBlockCoord.x] * 255.0f)));
 						}
 					}
@@ -385,20 +367,18 @@ namespace rgba_dxt3unorm
 			}
 		}
 
-		int Error(0);
+		int Error = 0;
 
 		Error += (TextureDecompressed == TextureLocalDecompressed) ? 0 : 1;
 
 		// Test converting through the convertFunc interface
 		// sampling at the corners of each level
-		for(int Level = 0; Level < TextureDecompressed.levels(); ++Level)
-		{
+		for (int Level = 0; Level < TextureDecompressed.levels(); ++Level) {
 			gli::extent2d TexelCoord;
 			gli::extent2d LevelExtent = TextureDecompressed.extent(Level);
-			for(TexelCoord.y = 0; TexelCoord.y < LevelExtent.y; TexelCoord.y += glm::max(1, LevelExtent.y - 1))
-			{
-				for(TexelCoord.x = 0; TexelCoord.x < LevelExtent.x; TexelCoord.x += glm::max(1, LevelExtent.x - 1))
-				{
+
+			for (TexelCoord.y = 0; TexelCoord.y < LevelExtent.y; TexelCoord.y += glm::max(1, LevelExtent.y - 1)) {
+				for (TexelCoord.x = 0; TexelCoord.x < LevelExtent.x; TexelCoord.x += glm::max(1, LevelExtent.x - 1)) {
 					glm::u8vec4 ColorFromCompressed = glm::u8vec4(glm::round(gli::detail::convertFunc<gli::texture2d, float, 4, std::uint8_t, glm::defaultp, gli::detail::CONVERT_MODE_DXT3UNORM, true>::fetch(TextureCompressed, TexelCoord, 0, 0, Level) * 255.0f));
 					glm::u8vec4 ColorFromDecompressed = TextureDecompressed.load<glm::u8vec4>(TexelCoord, Level);
 
@@ -409,12 +389,10 @@ namespace rgba_dxt3unorm
 
 		return Error;
 	}
-}//namespace rgba_dxt3unorm
+} // namespace rgba_dxt3unorm
 
-namespace rgba_dxt5unorm
-{
-	int test()
-	{
+namespace rgba_dxt5unorm {
+	int test() {
 		gli::texture2d TextureCompressed(gli::load(path("kueken7_rgba_dxt5_unorm.dds")));
 		GLI_ASSERT(!TextureCompressed.empty());
 
@@ -424,7 +402,10 @@ namespace rgba_dxt5unorm
 		GLI_ASSERT(TextureCompressed.extent() == TextureDecompressed.extent());
 		GLI_ASSERT(TextureCompressed.levels() == TextureDecompressed.levels());
 
-		gli::texture2d TextureLocalDecompressed(TextureDecompressed.format(), TextureDecompressed.extent(), TextureDecompressed.levels(), TextureDecompressed.swizzles());
+		gli::texture2d TextureLocalDecompressed(TextureDecompressed.format(),
+				TextureDecompressed.extent(),
+				TextureDecompressed.levels(),
+				TextureDecompressed.swizzles());
 
 		GLI_ASSERT(sizeof(gli::detail::dxt5_block) == gli::block_size(gli::FORMAT_RGBA_DXT5_UNORM_BLOCK16));
 
@@ -436,24 +417,20 @@ namespace rgba_dxt5unorm
 			BlockExtent.y = TempExtent.y;
 		}
 
-		for(size_t Level = 0; Level < TextureCompressed.levels(); ++Level)
-		{
+		for (size_t Level = 0; Level < TextureCompressed.levels(); ++Level) {
 			gli::extent2d TexelCoord;
 			gli::extent2d BlockCoord;
 			gli::extent2d LevelExtent = TextureCompressed.extent(Level);
 			gli::extent2d LevelExtentInBlocks = glm::max(gli::extent2d(1, 1), LevelExtent / BlockExtent);
-			for(BlockCoord.y = 0, TexelCoord.y = 0; BlockCoord.y < LevelExtentInBlocks.y; ++BlockCoord.y, TexelCoord.y += BlockExtent.y)
-			{
-				for(BlockCoord.x = 0, TexelCoord.x = 0; BlockCoord.x < LevelExtentInBlocks.x; ++BlockCoord.x, TexelCoord.x += BlockExtent.x)
-				{
+
+			for (BlockCoord.y = 0, TexelCoord.y = 0; BlockCoord.y < LevelExtentInBlocks.y; ++BlockCoord.y, TexelCoord.y += BlockExtent.y) {
+				for (BlockCoord.x = 0, TexelCoord.x = 0; BlockCoord.x < LevelExtentInBlocks.x; ++BlockCoord.x, TexelCoord.x += BlockExtent.x) {
 					const gli::detail::dxt5_block *DXT5Block = TextureCompressed.data<gli::detail::dxt5_block>(0, 0, Level) + (BlockCoord.y * LevelExtentInBlocks.x + BlockCoord.x);
 					const gli::detail::texel_block4x4 DecompressedBlock = gli::detail::decompress_dxt5_block(*DXT5Block);
 
 					gli::extent2d DecompressedBlockCoord;
-					for(DecompressedBlockCoord.y = 0; DecompressedBlockCoord.y < glm::min(4, LevelExtent.y); ++DecompressedBlockCoord.y)
-					{
-						for(DecompressedBlockCoord.x = 0; DecompressedBlockCoord.x < glm::min(4, LevelExtent.x); ++DecompressedBlockCoord.x)
-						{
+					for (DecompressedBlockCoord.y = 0; DecompressedBlockCoord.y < glm::min(4, LevelExtent.y); ++DecompressedBlockCoord.y) {
+						for (DecompressedBlockCoord.x = 0; DecompressedBlockCoord.x < glm::min(4, LevelExtent.x); ++DecompressedBlockCoord.x) {
 							TextureLocalDecompressed.store(TexelCoord + DecompressedBlockCoord, Level, glm::u8vec4(glm::round(DecompressedBlock.Texel[DecompressedBlockCoord.y][DecompressedBlockCoord.x] * 255.0f)));
 						}
 					}
@@ -461,20 +438,17 @@ namespace rgba_dxt5unorm
 			}
 		}
 
-		int Error(0);
+		int Error = 0;
 
 		Error += (TextureDecompressed == TextureLocalDecompressed) ? 0 : 1;
 
 		// Test converting through the convertFunc interface
 		// sampling at the corners of each level
-		for(int Level = 0; Level < TextureDecompressed.levels(); ++Level)
-		{
+		for (int Level = 0; Level < TextureDecompressed.levels(); ++Level) {
 			gli::extent2d TexelCoord;
 			gli::extent2d LevelExtent = TextureDecompressed.extent(Level);
-			for(TexelCoord.y = 0; TexelCoord.y < LevelExtent.y; TexelCoord.y += glm::max(1, LevelExtent.y - 1))
-			{
-				for(TexelCoord.x = 0; TexelCoord.x < LevelExtent.x; TexelCoord.x += glm::max(1, LevelExtent.x - 1))
-				{
+			for (TexelCoord.y = 0; TexelCoord.y < LevelExtent.y; TexelCoord.y += glm::max(1, LevelExtent.y - 1)) {
+				for (TexelCoord.x = 0; TexelCoord.x < LevelExtent.x; TexelCoord.x += glm::max(1, LevelExtent.x - 1)) {
 					glm::u8vec4 ColorFromCompressed = glm::u8vec4(glm::round(gli::detail::convertFunc<gli::texture2d, float, 4, std::uint8_t, glm::defaultp, gli::detail::CONVERT_MODE_DXT5UNORM, true>::fetch(TextureCompressed, TexelCoord, 0, 0, Level) * 255.0f));
 					glm::u8vec4 ColorFromDecompressed = TextureDecompressed.load<glm::u8vec4>(TexelCoord, Level);
 
@@ -485,12 +459,10 @@ namespace rgba_dxt5unorm
 
 		return Error;
 	}
-}//namespace rgba_dxt5unorm
+} // namespace rgba_dxt5unorm
 
-namespace r_bc4unorm
-{
-	int test()
-	{
+namespace r_bc4unorm {
+	int test() {
 		gli::texture2d TextureCompressed(gli::load(path("kueken7_r_ati1n_unorm.dds")));
 		GLI_ASSERT(!TextureCompressed.empty());
 
@@ -512,24 +484,20 @@ namespace r_bc4unorm
 			BlockExtent.y = TempExtent.y;
 		}
 
-		for(size_t Level = 0; Level < TextureCompressed.levels(); ++Level)
-		{
+		for (size_t Level = 0; Level < TextureCompressed.levels(); ++Level) {
 			gli::extent2d TexelCoord;
 			gli::extent2d BlockCoord;
 			gli::extent2d LevelExtent = TextureCompressed.extent(Level);
 			gli::extent2d LevelExtentInBlocks = glm::max(gli::extent2d(1, 1), LevelExtent / BlockExtent);
-			for(BlockCoord.y = 0, TexelCoord.y = 0; BlockCoord.y < LevelExtentInBlocks.y; ++BlockCoord.y, TexelCoord.y += BlockExtent.y)
-			{
-				for(BlockCoord.x = 0, TexelCoord.x = 0; BlockCoord.x < LevelExtentInBlocks.x; ++BlockCoord.x, TexelCoord.x += BlockExtent.x)
-				{
+
+			for (BlockCoord.y = 0, TexelCoord.y = 0; BlockCoord.y < LevelExtentInBlocks.y; ++BlockCoord.y, TexelCoord.y += BlockExtent.y) {
+				for (BlockCoord.x = 0, TexelCoord.x = 0; BlockCoord.x < LevelExtentInBlocks.x; ++BlockCoord.x, TexelCoord.x += BlockExtent.x) {
 					const gli::detail::bc4_block *BC4Block = TextureCompressed.data<gli::detail::bc4_block>(0, 0, Level) + (BlockCoord.y * LevelExtentInBlocks.x + BlockCoord.x);
 					const gli::detail::texel_block4x4 DecompressedBlock = gli::detail::decompress_bc4unorm_block(*BC4Block);
 
 					gli::extent2d DecompressedBlockCoord;
-					for(DecompressedBlockCoord.y = 0; DecompressedBlockCoord.y < glm::min(4, LevelExtent.y); ++DecompressedBlockCoord.y)
-					{
-						for(DecompressedBlockCoord.x = 0; DecompressedBlockCoord.x < glm::min(4, LevelExtent.x); ++DecompressedBlockCoord.x)
-						{
+					for (DecompressedBlockCoord.y = 0; DecompressedBlockCoord.y < glm::min(4, LevelExtent.y); ++DecompressedBlockCoord.y) {
+						for (DecompressedBlockCoord.x = 0; DecompressedBlockCoord.x < glm::min(4, LevelExtent.x); ++DecompressedBlockCoord.x) {
 							glm::u8vec4 rgbaTexel(glm::round(DecompressedBlock.Texel[DecompressedBlockCoord.y][DecompressedBlockCoord.x] * 255.0f));							
 							TextureLocalDecompressed.store(TexelCoord + DecompressedBlockCoord, Level, rgbaTexel.r);
 						}
@@ -538,20 +506,17 @@ namespace r_bc4unorm
 			}
 		}
 
-		int Error(0);
+		int Error = 0;
 
 		Error += (TextureDecompressed == TextureLocalDecompressed) ? 0 : 1;
 
 		// Test converting through the convertFunc interface
 		// sampling at the corners of each level
-		for(int Level = 0; Level < TextureDecompressed.levels(); ++Level)
-		{
+		for (int Level = 0; Level < TextureDecompressed.levels(); ++Level) {
 			gli::extent2d TexelCoord;
 			gli::extent2d LevelExtent = TextureDecompressed.extent(Level);
-			for(TexelCoord.y = 0; TexelCoord.y < LevelExtent.y; TexelCoord.y += glm::max(1, LevelExtent.y - 1))
-			{
-				for(TexelCoord.x = 0; TexelCoord.x < LevelExtent.x; TexelCoord.x += glm::max(1, LevelExtent.x - 1))
-				{
+			for (TexelCoord.y = 0; TexelCoord.y < LevelExtent.y; TexelCoord.y += glm::max(1, LevelExtent.y - 1)) {
+				for (TexelCoord.x = 0; TexelCoord.x < LevelExtent.x; TexelCoord.x += glm::max(1, LevelExtent.x - 1)) {
 					glm::u8vec4 ColorFromCompressed = glm::u8vec4(glm::round(gli::detail::convertFunc<gli::texture2d, float, 4, std::uint8_t, glm::defaultp, gli::detail::CONVERT_MODE_BC4UNORM, true>::fetch(TextureCompressed, TexelCoord, 0, 0, Level) * 255.0f));
 					glm::u8 ColorFromDecompressed = TextureDecompressed.load<glm::u8>(TexelCoord, Level);
 
@@ -562,12 +527,10 @@ namespace r_bc4unorm
 
 		return Error;
 	}
-}//namespace r_bc4unorm
+} // namespace r_bc4unorm
 
-namespace rg_bc5unorm
-{
-	int test()
-	{
+namespace rg_bc5unorm {
+	int test() {
 		gli::texture2d TextureCompressed(gli::load(path("kueken7_rg_ati2n_unorm.dds")));
 		GLI_ASSERT(!TextureCompressed.empty());
 
@@ -593,36 +556,28 @@ namespace rg_bc5unorm
 		uint32_t offByAlot = 0;
 		uint32_t onPoint = 0;
 
-		for(size_t Level = 0; Level < TextureCompressed.levels(); ++Level)
-		{
+		for (size_t Level = 0; Level < TextureCompressed.levels(); ++Level) {
 			gli::extent2d TexelCoord;
 			gli::extent2d BlockCoord;
 			gli::extent2d LevelExtent = TextureCompressed.extent(Level);
 			gli::extent2d LevelExtentInBlocks = glm::max(gli::extent2d(1, 1), LevelExtent / BlockExtent);
-			for(BlockCoord.y = 0, TexelCoord.y = 0; BlockCoord.y < LevelExtentInBlocks.y; ++BlockCoord.y, TexelCoord.y += BlockExtent.y)
-			{
-				for(BlockCoord.x = 0, TexelCoord.x = 0; BlockCoord.x < LevelExtentInBlocks.x; ++BlockCoord.x, TexelCoord.x += BlockExtent.x)
-				{
+			for (BlockCoord.y = 0, TexelCoord.y = 0; BlockCoord.y < LevelExtentInBlocks.y; ++BlockCoord.y, TexelCoord.y += BlockExtent.y) {
+				for (BlockCoord.x = 0, TexelCoord.x = 0; BlockCoord.x < LevelExtentInBlocks.x; ++BlockCoord.x, TexelCoord.x += BlockExtent.x) {
 					const gli::detail::bc5_block *BC5Block = TextureCompressed.data<gli::detail::bc5_block>(0, 0, Level) + (BlockCoord.y * LevelExtentInBlocks.x + BlockCoord.x);
 					const gli::detail::texel_block4x4 DecompressedBlock = gli::detail::decompress_bc5unorm_block(*BC5Block);
 
 					gli::extent2d DecompressedBlockCoord;
-					for(DecompressedBlockCoord.y = 0; DecompressedBlockCoord.y < glm::min(4, LevelExtent.y); ++DecompressedBlockCoord.y)
-					{
-						for(DecompressedBlockCoord.x = 0; DecompressedBlockCoord.x < glm::min(4, LevelExtent.x); ++DecompressedBlockCoord.x)
-						{
+					for (DecompressedBlockCoord.y = 0; DecompressedBlockCoord.y < glm::min(4, LevelExtent.y); ++DecompressedBlockCoord.y) {
+						for (DecompressedBlockCoord.x = 0; DecompressedBlockCoord.x < glm::min(4, LevelExtent.x); ++DecompressedBlockCoord.x) {
 							glm::u8vec4 rgbaTexel(glm::round(DecompressedBlock.Texel[DecompressedBlockCoord.y][DecompressedBlockCoord.x] * 255.0f));
 							
 							glm::u8vec2 decompressed = TextureDecompressed.load<glm::u8vec2>(TexelCoord + DecompressedBlockCoord, Level);
 
-							if(glm::xy(rgbaTexel) == decompressed)
-							{
+							if (glm::xy(rgbaTexel) == decompressed) {
 								++onPoint;
-							} else if(glm::abs((int32_t)rgbaTexel.r - (int32_t)decompressed.r) > 1 || glm::abs((int32_t)rgbaTexel.g - (int32_t)decompressed.g) > 1)
-							{
+							} else if (glm::abs((int32_t)rgbaTexel.r - (int32_t)decompressed.r) > 1 || glm::abs((int32_t)rgbaTexel.g - (int32_t)decompressed.g) > 1) {
 								++offByAlot;
-							} else
-							{
+							} else {
 								++offByOne;
 							}
 
@@ -633,20 +588,17 @@ namespace rg_bc5unorm
 			}
 		}
 
-		int Error(0);
+		int Error = 0;
 
 		Error += (TextureDecompressed == TextureLocalDecompressed) ? 0 : 1;
 
 		// Test converting through the convertFunc interface
 		// sampling at the corners of each level
-		for(int Level = 0; Level < TextureDecompressed.levels(); ++Level)
-		{
+		for (int Level = 0; Level < TextureDecompressed.levels(); ++Level) {
 			gli::extent2d TexelCoord;
 			gli::extent2d LevelExtent = TextureDecompressed.extent(Level);
-			for(TexelCoord.y = 0; TexelCoord.y < LevelExtent.y; TexelCoord.y += glm::max(1, LevelExtent.y - 1))
-			{
-				for(TexelCoord.x = 0; TexelCoord.x < LevelExtent.x; TexelCoord.x += glm::max(1, LevelExtent.x - 1))
-				{
+			for (TexelCoord.y = 0; TexelCoord.y < LevelExtent.y; TexelCoord.y += glm::max(1, LevelExtent.y - 1)) {
+				for (TexelCoord.x = 0; TexelCoord.x < LevelExtent.x; TexelCoord.x += glm::max(1, LevelExtent.x - 1)) {
 					glm::u8vec4 ColorFromCompressed = glm::u8vec4(glm::round(gli::detail::convertFunc<gli::texture2d, float, 4, std::uint8_t, glm::defaultp, gli::detail::CONVERT_MODE_BC5UNORM, true>::fetch(TextureCompressed, TexelCoord, 0, 0, Level) * 255.0f));
 					glm::u8vec2 ColorFromDecompressed = TextureDecompressed.load<glm::u8vec2>(TexelCoord, Level);
 
@@ -657,13 +609,11 @@ namespace rg_bc5unorm
 
 		return Error;
 	}
-}//namespace rg_bc5unorm
+} // namespace rg_bc5unorm
 
-namespace load_file
-{
-	int test()
-	{
-		int Error(0);
+namespace load_file {
+	int test() {
+		int Error = 0;
 
 		gli::texture2d TextureA(gli::load(path("kueken7_rgba16_sfloat.ktx")));
 		GLI_ASSERT(!TextureA.empty());
@@ -685,10 +635,9 @@ namespace load_file
 
 		return Error;
 	}
-}//namespace load_file
+} // namespace load_file
 
-int main()
-{
+int main() {
 	int Error = 0;
 
 	Error += load_file::test();

--- a/test/core/core_flip.cpp
+++ b/test/core/core_flip.cpp
@@ -1,82 +1,78 @@
 #include <gli/gli.hpp>
 
 template <typename texture, typename genType>
-int test_texture
-(
+int test_texture (
 	texture const & Texture,
 	genType const & ClearColor,
 	genType const & FirstColor
 )
+
 {
-	int Error(0);
+	int Error = 0;
 
 	texture TextureA(gli::duplicate(Texture));
 	TextureA.template clear<genType>(ClearColor);
 	*TextureA.template data<genType>() = FirstColor;
 
 	texture TextureB = gli::flip(TextureA);
-	Error += TextureA != TextureB ? 0 : 1;
+	Error += (TextureA != TextureB) ? 0 : 1;
 
 	texture TextureC = gli::flip(TextureB);
-	Error += TextureC == TextureA ? 0 : 1;
+	Error += (TextureC == TextureA) ? 0 : 1;
 
 	return Error;
 }
 
-int main()
-{
+int main() {
 	static_assert(sizeof(gli::detail::dxt1_block) == 8, "DXT1-compressed block must be of size 8.");
 	static_assert(sizeof(gli::detail::dxt3_block) == 16, "DXT3-compressed block must be of size 16.");
 	static_assert(sizeof(gli::detail::dxt5_block) == 16, "DXT5-compressed block must be of size 16.");
 
-	int Error(0);
+	int Error = 0;
 
-	gli::texture2d::extent_type const TextureSize(32);
-	gli::size_t const Levels = gli::levels(TextureSize);
+	const gli::texture2d::extent_type TextureSize(32);
+	const gli::size_t Levels = gli::levels(TextureSize);
 
-	Error += test_texture(
-		gli::texture2d(gli::FORMAT_R8_UNORM_PACK8, TextureSize, Levels),
-		glm::uint8(255), glm::uint8(0));
+	Error += test_texture(gli::texture2d(gli::FORMAT_R8_UNORM_PACK8, TextureSize, Levels),
+		static_cast<glm::uint8>(255),
+		static_cast<glm::uint8>(0));
 
-	Error += test_texture(
-		gli::texture2d(gli::FORMAT_RGB8_UNORM_PACK8, TextureSize, Levels),
-		glm::u8vec3(255, 128, 0), glm::u8vec3(0, 128, 255));
+	Error += test_texture(gli::texture2d(gli::FORMAT_RGB8_UNORM_PACK8, TextureSize, Levels),
+		glm::u8vec3(255, 128, 0),
+		glm::u8vec3(0, 128, 255));
 
-	Error += test_texture(
-		gli::texture2d(gli::FORMAT_RGBA8_UNORM_PACK8, TextureSize, Levels),
-		glm::u8vec4(255, 128, 0, 255), glm::u8vec4(0, 128, 255, 255));
+	Error += test_texture(gli::texture2d(gli::FORMAT_RGBA8_UNORM_PACK8, TextureSize, Levels),
+		glm::u8vec4(255, 128, 0, 255),
+		glm::u8vec4(0, 128, 255, 255));
 
-	Error += test_texture(
-		gli::texture2d(gli::FORMAT_RGBA32_SFLOAT_PACK32, TextureSize, Levels),
-		glm::f32vec4(1.0, 0.5, 0.0, 1.0), glm::f32vec4(0.0, 0.5, 1.0, 1.0));
+	Error += test_texture(gli::texture2d(gli::FORMAT_RGBA32_SFLOAT_PACK32, TextureSize, Levels),
+		glm::f32vec4(1.0, 0.5, 0.0, 1.0),
+		glm::f32vec4(0.0, 0.5, 1.0, 1.0));
 
-	Error += test_texture(
-		gli::texture2d_array(gli::FORMAT_RGBA8_UNORM_PACK8, TextureSize, 4, Levels),
-		glm::u8vec4(255, 128, 0, 255), glm::u8vec4(0, 128, 255, 255));
+	Error += test_texture(gli::texture2d_array(gli::FORMAT_RGBA8_UNORM_PACK8, TextureSize, 4, Levels),
+		glm::u8vec4(255, 128, 0, 255),
+		glm::u8vec4(0, 128, 255, 255));
 
 	Error += test_texture(
 		gli::texture2d_array(gli::FORMAT_RGBA32_SFLOAT_PACK32, TextureSize, 4, Levels),
-		glm::f32vec4(1.0, 0.5, 0.0, 1.0), glm::f32vec4(0.0, 0.5, 1.0, 1.0));
+		glm::f32vec4(1.0, 0.5, 0.0, 1.0),
+		glm::f32vec4(0.0, 0.5, 1.0, 1.0));
 
-	Error += test_texture(
-		gli::texture2d(gli::FORMAT_RGB_DXT1_UNORM_BLOCK8, TextureSize, Levels),
-		gli::detail::dxt1_block{63721, 255, 228, 144, 64, 0},
-		gli::detail::dxt1_block{2516, 215, 152, 173, 215, 106});
+	Error += test_texture(gli::texture2d(gli::FORMAT_RGB_DXT1_UNORM_BLOCK8, TextureSize, Levels),
+		gli::detail::dxt1_block{ 63721, 255, { 228, 144, 64, 0 } },
+		gli::detail::dxt1_block{ 2516, 215, { 152, 173, 215, 106 } });
 
-	Error += test_texture(
-		gli::texture2d(gli::FORMAT_RGBA_DXT1_UNORM_BLOCK8, TextureSize, Levels),
-		gli::detail::dxt1_block{63721, 255, 228, 144, 64, 0},
-		gli::detail::dxt1_block{2516, 215, 152, 173, 215, 106});
+	Error += test_texture(gli::texture2d(gli::FORMAT_RGBA_DXT1_UNORM_BLOCK8, TextureSize, Levels),
+		gli::detail::dxt1_block{ 63721, 255, { 228, 144, 64, 0 } },
+		gli::detail::dxt1_block{ 2516, 215, { 152, 173, 215, 106 } });
 
-	Error += test_texture(
-		gli::texture2d(gli::FORMAT_RGBA_DXT3_UNORM_BLOCK16, TextureSize, Levels),
-		gli::detail::dxt3_block{12514, 1512, 12624, 16614, 63712, 255, 228, 144, 64, 0},
-		gli::detail::dxt3_block{36125, 2416, 46314, 10515, 2516, 215, 152, 173, 215, 106});
+	Error += test_texture(gli::texture2d(gli::FORMAT_RGBA_DXT3_UNORM_BLOCK16, TextureSize, Levels),
+		gli::detail::dxt3_block{ { 12514, 1512, 12624, 16614 }, 63712, 255, { 228, 144, 64, 0 } },
+		gli::detail::dxt3_block{ { 36125, 2416, 46314, 10515 }, 2516, 215, { 152, 173, 215, 106 } });
 
-	Error += test_texture(
-		gli::texture2d(gli::FORMAT_RGBA_DXT5_UNORM_BLOCK16, TextureSize, Levels),
-		gli::detail::dxt5_block{255, 0, 64, 30, 50, 45, 242, 68, 63712, 255, 228, 144, 64, 0},
-		gli::detail::dxt5_block{0, 255, 62, 144, 228, 214, 59, 200, 2516, 215, 152, 173, 215, 106});
+	Error += test_texture(gli::texture2d(gli::FORMAT_RGBA_DXT5_UNORM_BLOCK16, TextureSize, Levels),
+		gli::detail::dxt5_block{ { 255, 0 }, { 64, 30, 50, 45, 242, 68 }, 63712, 255, { 228, 144, 64, 0 }},
+		gli::detail::dxt5_block{ { 0, 255 }, { 62, 144, 228, 214, 59, 200 }, 2516, 215, { 152, 173, 215, 106 } });
 
 	return Error;
 }

--- a/test/core/core_texture.cpp
+++ b/test/core/core_texture.cpp
@@ -1,3 +1,7 @@
+#include <ctime>
+#include <iostream>
+#include <memory>
+
 #include <gli/texture.hpp>
 #include <gli/sampler2d.hpp>
 #include <gli/levels.hpp>
@@ -6,55 +10,44 @@
 #include <gli/load.hpp>
 #include <gli/copy.hpp>
 #include <gli/generate_mipmaps.hpp>
+
 #include <glm/gtc/epsilon.hpp>
-#include <ctime>
-#include <memory>
 
-namespace alloc
-{
-	int run()
-	{
-		int Error(0);
+namespace alloc {
+	int run() {
+		int Error = 0;
 
-		std::vector<int> Sizes;
-		Sizes.push_back(16);
-		Sizes.push_back(32);
-		Sizes.push_back(15);
-		Sizes.push_back(17);
-		Sizes.push_back(1);
+		std::vector<int> Sizes = { 16, 32, 15, 17, 1 };
 
-		for(std::size_t TargetIndex = gli::TARGET_FIRST; TargetIndex <= gli::TARGET_LAST; ++TargetIndex)
-		for(std::size_t FormatIndex = gli::FORMAT_FIRST; FormatIndex <= gli::FORMAT_LAST; ++FormatIndex)
-		{
-			gli::format const Format = static_cast<gli::format>(FormatIndex);
-			gli::target const Target = static_cast<gli::target>(TargetIndex);
-			gli::texture::size_type const Faces = gli::is_target_cube(Target) ? 6 : 1;
+		for (std::size_t TargetIndex = gli::TARGET_FIRST; TargetIndex <= gli::TARGET_LAST; ++TargetIndex) {
+			for (std::size_t FormatIndex = gli::FORMAT_FIRST; FormatIndex <= gli::FORMAT_LAST; ++FormatIndex) {
+				const gli::format Format = static_cast<gli::format>(FormatIndex);
+				const gli::target Target = static_cast<gli::target>(TargetIndex);
+				const gli::texture::size_type Faces = gli::is_target_cube(Target) ? 6 : 1;
 
-			if(gli::is_compressed(Format) && gli::is_target_1d(Target))
-				continue;
+				if (gli::is_compressed(Format) && gli::is_target_1d(Target))
+					continue;
 
-			for(std::size_t SizeIndex = 0; SizeIndex < Sizes.size(); ++SizeIndex)
-			{
-				gli::texture::extent_type Size(Sizes[SizeIndex]);
+				for (const auto Size: Sizes) {
+					gli::texture::extent_type _Size(Size);
 
-				gli::texture TextureA(Target, Format, Size, 1, Faces, gli::levels(Size));
-				gli::texture TextureB(Target, Format, Size, 1, Faces, gli::levels(Size));
+					gli::texture TextureA(Target, Format, _Size, 1, Faces, gli::levels(_Size));
+					gli::texture TextureB(Target, Format, _Size, 1, Faces, gli::levels(_Size));
 
-				Error += TextureA == TextureB ? 0 : 1;
+					Error += (TextureA == TextureB) ? 0 : 1;
+				}
 			}
 		}
 
 		return Error;
 	}
-}//namespace alloc
+} // namespace alloc
 
-namespace clear
-{
-	int run()
-	{
-		int Error(0);
+namespace clear {
+	int run() {
+		int Error = 0;
 
-		glm::u8vec4 const Orange(255, 127, 0, 255);
+		const glm::u8vec4 Orange(255, 127, 0, 255);
 
 		gli::texture::extent_type Size(16, 16, 1);
 		gli::texture Texture(gli::TARGET_2D, gli::FORMAT_RGBA8_UNORM_PACK8, Size, 1, 1, gli::levels(Size));
@@ -63,34 +56,30 @@ namespace clear
 
 		return Error;
 	}
-}//namespace
+} // namespace clear
 
-namespace query
-{
-	int run()
-	{
-		int Error(0);
+namespace query {
+	int run() {
+		int Error = 0;
 
-		gli::texture Texture(gli::TARGET_2D, gli::FORMAT_RGBA8_UINT_PACK8, gli::texture::extent_type(1), 1, 1, 1);
+		gli::texture Texture(gli::TARGET_2D, gli::FORMAT_RGBA8_UINT_PACK8, static_cast<gli::texture::extent_type>(1), 1, 1, 1);
 
-		Error += Texture.size() == sizeof(glm::u8vec4) * 1 ? 0 : 1;
-		Error += Texture.format() == gli::FORMAT_RGBA8_UINT_PACK8 ? 0 : 1;
-		Error += Texture.levels() == 1 ? 0 : 1;
+		Error += (Texture.size() == sizeof(glm::u8vec4) * 1) ? 0 : 1;
+		Error += (Texture.format() == gli::FORMAT_RGBA8_UINT_PACK8) ? 0 : 1;
+		Error += (Texture.levels() == 1) ? 0 : 1;
 		Error += !Texture.empty() ? 0 : 1;
-		Error += Texture.extent() == gli::texture::extent_type(1) ? 0 : 1;
+		Error += (Texture.extent() == static_cast<gli::texture::extent_type>(1)) ? 0 : 1;
 
 		return Error;
 	}
-}//namespace
+} // namespace query
 
-namespace tex_access
-{
-	int run()
-	{
+namespace tex_access {
+	int run() {
 		int Error(0);
 
 		{
-			gli::texture1d Texture(gli::FORMAT_RGBA8_UINT_PACK8, gli::texture1d::extent_type(2), 2);
+			gli::texture1d Texture(gli::FORMAT_RGBA8_UINT_PACK8, static_cast<gli::texture1d::extent_type>(2), 2);
 			GLI_ASSERT(!Texture.empty());
 
 			gli::image Image0 = Texture[0];
@@ -99,8 +88,8 @@ namespace tex_access
 			std::size_t Size0 = Image0.size();
 			std::size_t Size1 = Image1.size();
 
-			Error += Size0 == sizeof(glm::u8vec4) * 2 ? 0 : 1;
-			Error += Size1 == sizeof(glm::u8vec4) * 1 ? 0 : 1;
+			Error += (Size0 == sizeof(glm::u8vec4) * 2) ? 0 : 1;
+			Error += (Size1 == sizeof(glm::u8vec4) * 1) ? 0 : 1;
 
 			*Image0.data<glm::u8vec4>() = glm::u8vec4(255, 127, 0, 255);
 			*Image1.data<glm::u8vec4>() = glm::u8vec4(0, 127, 255, 255);
@@ -111,8 +100,8 @@ namespace tex_access
 			glm::u8vec4 * Pointer0 = Texture.data<glm::u8vec4>() + 0;
 			glm::u8vec4 * Pointer1 = Texture.data<glm::u8vec4>() + 2;
 
-			Error += PointerA == Pointer0 ? 0 : 1;
-			Error += PointerB == Pointer1 ? 0 : 1;
+			Error += (PointerA == Pointer0) ? 0 : 1;
+			Error += (PointerB == Pointer1) ? 0 : 1;
 
 			glm::u8vec4 ColorA = *Image0.data<glm::u8vec4>();
 			glm::u8vec4 ColorB = *Image1.data<glm::u8vec4>();
@@ -120,18 +109,18 @@ namespace tex_access
 			glm::u8vec4 Color0 = *Pointer0;
 			glm::u8vec4 Color1 = *Pointer1;
 
-			Error += ColorA == Color0 ? 0 : 1;
-			Error += ColorB == Color1 ? 0 : 1;
+			Error += (ColorA == Color0) ? 0 : 1;
+			Error += (ColorB == Color1) ? 0 : 1;
 
 			Error += glm::all(glm::equal(Color0, glm::u8vec4(255, 127, 0, 255))) ? 0 : 1;
 			Error += glm::all(glm::equal(Color1, glm::u8vec4(0, 127, 255, 255))) ? 0 : 1;
 		}
 
 		{
-			gli::texture Texture(gli::TARGET_2D, gli::FORMAT_RGBA8_UINT_PACK8, gli::texture::extent_type(1), 1, 1, 1);
+			gli::texture Texture(gli::TARGET_2D, gli::FORMAT_RGBA8_UINT_PACK8, static_cast<gli::texture::extent_type>(1), 1, 1, 1);
 
 			std::size_t SizeA = Texture.size();
-			Error += SizeA == sizeof(glm::u8vec4) * 1 ? 0 : 1;
+			Error += (SizeA == sizeof(glm::u8vec4) * 1) ? 0 : 1;
 
 			*Texture.data<glm::u8vec4>() = glm::u8vec4(255, 127, 0, 255);
 
@@ -143,16 +132,14 @@ namespace tex_access
 
 		return Error;
 	}
-}//namespace
+} // namespace tex_access
 
-namespace size
-{
-	struct test
-	{
+namespace size {
+	struct test {
 		test(
-			gli::format const & Format,
-			gli::texture::extent_type const & Dimensions,
-			gli::texture::size_type const & Size) :
+			const gli::format& Format,
+			const gli::texture::extent_type& Dimensions,
+			const gli::texture::size_type& Size) :
 			Format(Format),
 			Dimensions(Dimensions),
 			Size(Size)
@@ -163,39 +150,36 @@ namespace size
 		gli::texture::size_type Size;
 	};
 
-	int run()
-	{
-		int Error(0);
+	int run() {
+		int Error = 0;
 
-		std::vector<test> Tests;
-		Tests.push_back(test(gli::FORMAT_RGBA8_UINT_PACK8, gli::texture::extent_type(1), 4));
-		Tests.push_back(test(gli::FORMAT_R8_UINT_PACK8, gli::texture::extent_type(1), 1));
+		std::vector<test> Tests = {
+			test(gli::FORMAT_RGBA8_UINT_PACK8, static_cast<gli::texture::extent_type>(1), 4),
+			test(gli::FORMAT_R8_UINT_PACK8, static_cast<gli::texture::extent_type>(1), 1)
+		};
 
-		for(std::size_t i = 0; i < Tests.size(); ++i)
-		{
+		for (const auto& Test: Tests) {
 			gli::texture Texture(
 				gli::TARGET_2D,
-				Tests[i].Format,
-				gli::texture::extent_type(1),
-				gli::texture::size_type(1),
-				gli::texture::size_type(1),
-				gli::texture::size_type(1));
+				Test.Format,
+				static_cast<gli::texture::extent_type>(1),
+				static_cast<gli::texture::size_type>(1),
+				static_cast<gli::texture::size_type>(1),
+				static_cast<gli::texture::size_type>(1));
 
-			Error += Texture.size() == Tests[i].Size ? 0 : 1;
+			Error += (Texture.size() == Test.Size) ? 0 : 1;
 			GLI_ASSERT(!Error);
 		}
 
 		return Error;
 	}
-}//namespace size
+} // namespace size
 
-namespace specialize
-{
-	int run()
-	{
-		int Error(0);
+namespace specialize {
+	int run() {
+		int Error = 0;
 
-		gli::texture Texture(gli::TARGET_1D, gli::FORMAT_RGBA8_UNORM_PACK8, gli::texture::extent_type(1), 1, 1, 1);
+		gli::texture Texture(gli::TARGET_1D, gli::FORMAT_RGBA8_UNORM_PACK8, static_cast<gli::texture::extent_type>(1), 1, 1, 1);
 		gli::texture1d Texture1D(Texture);
 		gli::texture1d_array Texture1DArray(Texture);
 		gli::texture2d Texture2D(Texture);
@@ -204,13 +188,13 @@ namespace specialize
 		gli::texture_cube TextureCube(Texture);
 		gli::texture_cube_array TextureCubeArray(Texture);
 
-		Error += Texture == Texture1D ? 0 : 1;
-		Error += Texture != Texture1DArray ? 0 : 1;
-		Error += Texture != Texture2D ? 0 : 1;
-		Error += Texture != Texture2DArray ? 0 : 1;
-		Error += Texture != Texture3D ? 0 : 1;
-		Error += Texture != TextureCube ? 0 : 1;
-		Error += Texture != TextureCubeArray ? 0 : 1;
+		Error += (Texture == Texture1D) ? 0 : 1;
+		Error += (Texture != Texture1DArray) ? 0 : 1;
+		Error += (Texture != Texture2D) ? 0 : 1;
+		Error += (Texture != Texture2DArray) ? 0 : 1;
+		Error += (Texture != Texture3D) ? 0 : 1;
+		Error += (Texture != TextureCube) ? 0 : 1;
+		Error += (Texture != TextureCubeArray) ? 0 : 1;
 
 		gli::texture Texture1D_B(Texture1D);
 		gli::texture Texture1DArray_B(Texture1DArray);
@@ -220,35 +204,33 @@ namespace specialize
 		gli::texture TextureCube_B(TextureCube);
 		gli::texture TextureCubeArray_B(TextureCubeArray);
 
-		Error += Texture == Texture1D_B ? 0 : 1;
-		Error += Texture != Texture1DArray_B ? 0 : 1;
-		Error += Texture != Texture2D_B ? 0 : 1;
-		Error += Texture != Texture2DArray_B ? 0 : 1;
-		Error += Texture != Texture3D_B ? 0 : 1;
-		Error += Texture != TextureCube_B ? 0 : 1;
-		Error += Texture != TextureCubeArray_B ? 0 : 1;
+		Error += (Texture == Texture1D_B) ? 0 : 1;
+		Error += (Texture != Texture1DArray_B) ? 0 : 1;
+		Error += (Texture != Texture2D_B) ? 0 : 1;
+		Error += (Texture != Texture2DArray_B) ? 0 : 1;
+		Error += (Texture != Texture3D_B) ? 0 : 1;
+		Error += (Texture != TextureCube_B) ? 0 : 1;
+		Error += (Texture != TextureCubeArray_B) ? 0 : 1;
 
-		Error += Texture1D == Texture1D_B ? 0 : 1;
-		Error += Texture1DArray == Texture1DArray_B ? 0 : 1;
-		Error += Texture2D == Texture2D_B ? 0 : 1;
-		Error += Texture2DArray == Texture2DArray_B ? 0 : 1;
-		Error += Texture3D == Texture3D_B ? 0 : 1;
-		Error += TextureCube == TextureCube_B ? 0 : 1;
-		Error += TextureCubeArray == TextureCubeArray_B ? 0 : 1;
+		Error += (Texture1D == Texture1D_B) ? 0 : 1;
+		Error += (Texture1DArray == Texture1DArray_B) ? 0 : 1;
+		Error += (Texture2D == Texture2D_B) ? 0 : 1;
+		Error += (Texture2DArray == Texture2DArray_B) ? 0 : 1;
+		Error += (Texture3D == Texture3D_B) ? 0 : 1;
+		Error += (TextureCube == TextureCube_B) ? 0 : 1;
+		Error += (TextureCubeArray == TextureCubeArray_B) ? 0 : 1;
 
 		return Error;
 	}
-}//namespace specialize
+} // namespace specialize
 
-namespace load
-{
-	int run()
-	{
+namespace load {
+	int run() {
 		int Error = 0;
 
 		// Texture 1D
 		{
-			gli::texture Texture(gli::TARGET_1D, gli::FORMAT_RGBA8_UNORM_PACK8, gli::texture::extent_type(1), 1, 1, 1);
+			gli::texture Texture(gli::TARGET_1D, gli::FORMAT_RGBA8_UNORM_PACK8, static_cast<gli::texture::extent_type>(1), 1, 1, 1);
 			Texture.clear(glm::u8vec4(225, 127, 0, 255));
 
 			gli::save(Texture, "texture_1d.ktx");
@@ -256,26 +238,26 @@ namespace load
 			gli::texture TextureKTX = gli::load("texture_1d.ktx");
 			gli::texture TextureDDS = gli::load("texture_1d.dds");
 
-			Error += Texture == TextureKTX ? 0 : 1;
-			Error += Texture == TextureDDS ? 0 : 1;
+			Error += (Texture == TextureKTX) ? 0 : 1;
+			Error += (Texture == TextureDDS) ? 0 : 1;
 		}
 
 		// Texture 1D array
 		{
-			gli::texture Texture(gli::TARGET_1D_ARRAY, gli::FORMAT_RGBA8_UNORM_PACK8, gli::texture::extent_type(1), 2, 1, 1);
+			gli::texture Texture(gli::TARGET_1D_ARRAY, gli::FORMAT_RGBA8_UNORM_PACK8, static_cast<gli::texture::extent_type>(1), 2, 1, 1);
 			Texture.clear(glm::u8vec4(225, 127, 0, 255));
 			gli::save(Texture, "texture_1d_array.ktx");
 			gli::save(Texture, "texture_1d_array.dds");
 			gli::texture TextureKTX = gli::load("texture_1d_array.ktx");
 			gli::texture TextureDDS = gli::load("texture_1d_array.dds");
 
-			Error += Texture == TextureKTX ? 0 : 1;
-			Error += Texture == TextureDDS ? 0 : 1;
+			Error += (Texture == TextureKTX) ? 0 : 1;
+			Error += (Texture == TextureDDS) ? 0 : 1;
 		}
 
 		// Texture 2D
 		{
-			gli::texture Texture(gli::TARGET_2D, gli::FORMAT_RGBA8_UNORM_PACK8, gli::texture::extent_type(1), 1, 1, 1);
+			gli::texture Texture(gli::TARGET_2D, gli::FORMAT_RGBA8_UNORM_PACK8, static_cast<gli::texture::extent_type>(1), 1, 1, 1);
 			Texture.clear(glm::u8vec4(225, 127, 0, 255));
 
 			gli::save(Texture, "texture_2d.ktx");
@@ -283,176 +265,164 @@ namespace load
 			gli::texture TextureKTX = gli::load("texture_2d.ktx");
 			gli::texture TextureDDS = gli::load("texture_2d.dds");
 
-			Error += Texture == TextureKTX ? 0 : 1;
-			Error += Texture == TextureDDS ? 0 : 1;
+			Error += (Texture == TextureKTX) ? 0 : 1;
+			Error += (Texture == TextureDDS) ? 0 : 1;
 		}
 
 		// Texture 2D array
 		{
-			gli::texture Texture(gli::TARGET_2D_ARRAY, gli::FORMAT_RGBA8_UNORM_PACK8, gli::texture::extent_type(1), 2, 1, 1);
+			gli::texture Texture(gli::TARGET_2D_ARRAY, gli::FORMAT_RGBA8_UNORM_PACK8, static_cast<gli::texture::extent_type>(1), 2, 1, 1);
 			Texture.clear(glm::u8vec4(225, 127, 0, 255));
 			gli::save(Texture, "texture_2d_array.ktx");
 			gli::save(Texture, "texture_2d_array.dds");
 			gli::texture TextureKTX = gli::load("texture_2d_array.ktx");
 			gli::texture TextureDDS = gli::load("texture_2d_array.dds");
 
-			Error += Texture == TextureKTX ? 0 : 1;
-			Error += Texture == TextureDDS ? 0 : 1;
+			Error += (Texture == TextureKTX) ? 0 : 1;
+			Error += (Texture == TextureDDS) ? 0 : 1;
 		}
 
 		// Texture 3D
 		{
-			gli::texture Texture(gli::TARGET_3D, gli::FORMAT_RGBA8_UNORM_PACK8, gli::texture::extent_type(1), 1, 1, 1);
+			gli::texture Texture(gli::TARGET_3D, gli::FORMAT_RGBA8_UNORM_PACK8, static_cast<gli::texture::extent_type>(1), 1, 1, 1);
 			gli::save(Texture, "texture_3d.ktx");
 			gli::save(Texture, "texture_3d.dds");
 			gli::texture TextureKTX = gli::load("texture_3d.ktx");
 			gli::texture TextureDDS = gli::load("texture_3d.dds");
 
-			Error += Texture == TextureKTX ? 0 : 1;
-			Error += Texture == TextureDDS ? 0 : 1;
+			Error += (Texture == TextureKTX) ? 0 : 1;
+			Error += (Texture == TextureDDS) ? 0 : 1;
 		}
 
 		// Texture cube
 		{
-			gli::texture Texture(gli::TARGET_CUBE, gli::FORMAT_RGBA8_UNORM_PACK8, gli::texture::extent_type(1), 1, 6, 1);
+			gli::texture Texture(gli::TARGET_CUBE, gli::FORMAT_RGBA8_UNORM_PACK8, static_cast<gli::texture::extent_type>(1), 1, 6, 1);
 			Texture.clear(glm::u8vec4(225, 127, 0, 255));
 			gli::save(Texture, "texture_cube.ktx");
 			gli::save(Texture, "texture_cube.dds");
 			gli::texture TextureKTX = gli::load("texture_cube.ktx");
 			gli::texture TextureDDS = gli::load("texture_cube.dds");
 
-			Error += Texture == TextureKTX ? 0 : 1;
-			Error += Texture == TextureDDS ? 0 : 1;
+			Error += (Texture == TextureKTX) ? 0 : 1;
+			Error += (Texture == TextureDDS) ? 0 : 1;
 		}
 
 		// Texture cube array
 		{
-			gli::texture Texture(gli::TARGET_CUBE_ARRAY, gli::FORMAT_RGBA8_UNORM_PACK8, gli::texture::extent_type(1), 2, 6, 1);
+			gli::texture Texture(gli::TARGET_CUBE_ARRAY, gli::FORMAT_RGBA8_UNORM_PACK8, static_cast<gli::texture::extent_type>(1), 2, 6, 1);
 			Texture.clear(glm::u8vec4(225, 127, 0, 255));
 			gli::save(Texture, "texture_cube_array.ktx");
 			gli::save(Texture, "texture_cube_array.dds");
 			gli::texture TextureKTX = gli::load("texture_cube_array.ktx");
 			gli::texture TextureDDS = gli::load("texture_cube_array.dds");
 
-			Error += Texture == TextureKTX ? 0 : 1;
-			Error += Texture == TextureDDS ? 0 : 1;
+			Error += (Texture == TextureKTX) ? 0 : 1;
+			Error += (Texture == TextureDDS) ? 0 : 1;
 		}
 
 		return Error;
 	}
-}//namespace load
+} // namespace load
 
-namespace data
-{
-	int run()
-	{
+namespace data {
+	int run() {
 		int Error = 0;
 
-		gli::texture Texture(gli::TARGET_2D_ARRAY, gli::FORMAT_RGBA8_UNORM_PACK8, gli::texture::extent_type(1), 2, 1, 1);
+		gli::texture Texture(gli::TARGET_2D_ARRAY, gli::FORMAT_RGBA8_UNORM_PACK8, static_cast<gli::texture::extent_type>(1), 2, 1, 1);
 		Error += gli::texture2d_array(Texture)[0].data() == Texture.data(0, 0, 0) ? 0 : 1;
 		Error += gli::texture2d_array(Texture)[1].data() == Texture.data(1, 0, 0) ? 0 : 1;
 
 		return Error;
 	}
-}//namespace data
+} // namespace data
 
-namespace perf_generic_creation
-{
-	int main(std::size_t Iterations)
-	{
+namespace perf_generic_creation {
+	int main(std::size_t Iterations) {
 		int Error = 0;
 
 		std::clock_t TimeBegin = std::clock();
 
-		for(std::size_t Index = 0, Count = Iterations; Index < Count; ++Index)
-		for(std::size_t FormatIndex = gli::FORMAT_FIRST, FormatCount = gli::FORMAT_COUNT; FormatIndex < FormatCount; ++FormatIndex)
-		{
-			gli::texture Texture(gli::TARGET_2D_ARRAY, static_cast<gli::format>(FormatIndex), gli::texture::extent_type(4, 4, 1), 1, 1, 3);
-			Error += Texture.empty() ? 1 : 0;
+		for (std::size_t Index = 0, Count = Iterations; Index < Count; ++Index) {
+			for (std::size_t FormatIndex = gli::FORMAT_FIRST, FormatCount = gli::FORMAT_COUNT; FormatIndex < FormatCount; ++FormatIndex) {
+				gli::texture Texture(gli::TARGET_2D_ARRAY, static_cast<gli::format>(FormatIndex), gli::texture::extent_type(4, 4, 1), 1, 1, 3);
+				Error += Texture.empty() ? 1 : 0;
+			}
 		}
 
 		std::clock_t TimeEnd = std::clock();
-		printf("Generic texture creation performance test: %d\n", TimeEnd - TimeBegin);
+		std::cout << "Generic texture creation performance test: " << TimeEnd - TimeBegin << std::endl;
 
 		return Error;
 	}
-}//namespace perf_generic_creation
+} // namespace perf_generic_creation
 
-namespace perf_2d_array_creation
-{
-	int main(std::size_t Iterations)
-	{
+namespace perf_2d_array_creation {
+	int main(std::size_t Iterations) {
 		int Error = 0;
 
 		std::clock_t TimeBegin = std::clock();
 
-		for(std::size_t Index = 0, Count = Iterations; Index < Count; ++Index)
-		for(std::size_t FormatIndex = gli::FORMAT_FIRST, FormatCount = gli::FORMAT_COUNT; FormatIndex < FormatCount; ++FormatIndex)
-		{
-			gli::texture2d_array Texture(static_cast<gli::format>(FormatIndex), gli::texture2d_array::extent_type(4), 1, 3);
-			Error += Texture.empty() ? 1 : 0;
+		for (std::size_t Index = 0, Count = Iterations; Index < Count; ++Index) {
+			for (std::size_t FormatIndex = gli::FORMAT_FIRST, FormatCount = gli::FORMAT_COUNT; FormatIndex < FormatCount; ++FormatIndex) {
+				gli::texture2d_array Texture(static_cast<gli::format>(FormatIndex), gli::texture2d_array::extent_type(4), 1, 3);
+				Error += Texture.empty() ? 1 : 0;
+			}
 		}
 
 		std::clock_t TimeEnd = std::clock();
-		printf("2D array texture creation performance test: %d\n", TimeEnd - TimeBegin);
+		std::cout << "2D array texture creation performance test: " << TimeEnd - TimeBegin << std::endl;
 
 		return Error;
 	}
-}//namespace perf_2d_array_creation
+} // namespace perf_2d_array_creation
 
-namespace perf_2d_creation
-{
-	int main(std::size_t Iterations)
-	{
+namespace perf_2d_creation {
+	int main(std::size_t Iterations) {
 		int Error = 0;
 
 		std::clock_t TimeBegin = std::clock();
 
-		for(std::size_t Index = 0, Count = Iterations; Index < Count; ++Index)
-		for(std::size_t FormatIndex = gli::FORMAT_FIRST, FormatCount = gli::FORMAT_COUNT; FormatIndex < FormatCount; ++FormatIndex)
-		{
-			gli::texture2d Texture(static_cast<gli::format>(FormatIndex), gli::texture2d::extent_type(4), 3);
-			Error += Texture.empty() ? 1 : 0;
+		for (std::size_t Index = 0, Count = Iterations; Index < Count; ++Index) {
+			for (std::size_t FormatIndex = gli::FORMAT_FIRST, FormatCount = gli::FORMAT_COUNT; FormatIndex < FormatCount; ++FormatIndex) {
+				gli::texture2d Texture(static_cast<gli::format>(FormatIndex), static_cast<gli::texture2d::extent_type>(4), 3);
+				Error += Texture.empty() ? 1 : 0;
+			}
 		}
 
 		std::clock_t TimeEnd = std::clock();
-		printf("2D texture creation performance test: %d\n", TimeEnd - TimeBegin);
+		std::cout << "2D texture creation performance test: " << TimeEnd - TimeBegin << std::endl;
 
 		return Error;
 	}
-}//namespace perf_2d_creation
+} // namespace perf_2d_creation
 
-namespace perf_cube_array_creation
-{
-	int main(std::size_t Iterations)
-	{
+namespace perf_cube_array_creation {
+	int main(std::size_t Iterations) {
 		int Error = 0;
 
 		std::clock_t TimeBegin = std::clock();
 
-		for(std::size_t Index = 0, Count = Iterations; Index < Count; ++Index)
-		for(std::size_t FormatIndex = gli::FORMAT_FIRST, FormatCount = gli::FORMAT_COUNT; FormatIndex < FormatCount; ++FormatIndex)
-		{
-			gli::texture_cube_array Texture(static_cast<gli::format>(FormatIndex), gli::texture2d_array::extent_type(4), 1, 3);
-			Error += Texture.empty() ? 1 : 0;
+		for (std::size_t Index = 0, Count = Iterations; Index < Count; ++Index) {
+			for (std::size_t FormatIndex = gli::FORMAT_FIRST, FormatCount = gli::FORMAT_COUNT; FormatIndex < FormatCount; ++FormatIndex) {
+				gli::texture_cube_array Texture(static_cast<gli::format>(FormatIndex), gli::texture2d_array::extent_type(4), 1, 3);
+				Error += Texture.empty() ? 1 : 0;
+			}
 		}
 
 		std::clock_t TimeEnd = std::clock();
-		printf("Cube array texture creation performance test: %d\n", TimeEnd - TimeBegin);
+		std::cout << "Cube array texture creation performance test: " << TimeEnd - TimeBegin << std::endl;
 
 		return Error;
 	}
-}//namespace perf_cube_array_creation
+} // namespace perf_cube_array_creation
 
-namespace perf_cube_array_access
-{
-	int main(std::size_t Iterations)
-	{
+namespace perf_cube_array_access {
+	int main(std::size_t Iterations) {
 		int Error = 0;
 
-		std::vector<std::shared_ptr<gli::texture_cube_array> > Textures(gli::FORMAT_COUNT);
-		for(std::size_t FormatIndex = gli::FORMAT_FIRST, FormatCount = gli::FORMAT_COUNT; FormatIndex < FormatCount; ++FormatIndex)
-		{
+		std::vector<std::shared_ptr<gli::texture_cube_array>> Textures(gli::FORMAT_COUNT);
+
+		for (std::size_t FormatIndex = gli::FORMAT_FIRST, FormatCount = gli::FORMAT_COUNT; FormatIndex < FormatCount; ++FormatIndex) {
 			Textures[FormatIndex].reset(new gli::texture_cube_array(static_cast<gli::format>(FormatIndex), gli::texture2d_array::extent_type(4), 3, 3));
 			Error += Textures[FormatIndex]->empty() ? 1 : 0;
 		}
@@ -460,411 +430,379 @@ namespace perf_cube_array_access
 		{
 			std::clock_t TimeBegin = std::clock();
 
-			for(gli::size_t Index = 0, Count = Iterations; Index < Count; ++Index)
-			for(std::size_t FormatIndex = gli::FORMAT_FIRST, FormatCount = gli::FORMAT_COUNT; FormatIndex < FormatCount; ++FormatIndex)
-			{
-				for(gli::size_t LayerIndex = 0, LayerCount = Textures[FormatIndex]->layers(); LayerIndex < LayerCount; ++LayerIndex)
-				for(gli::size_t LevelIndex = 0, LevelCount = Textures[FormatIndex]->levels(); LevelIndex < LevelCount; ++LevelIndex)
-				{
-					void* BaseAddress = Textures[FormatIndex]->data(LayerIndex, 0, LevelIndex);
-					Error += BaseAddress != nullptr ? 0 : 1;
+			for(gli::size_t Index = 0, Count = Iterations; Index < Count; ++Index) {
+				for (std::size_t FormatIndex = gli::FORMAT_FIRST, FormatCount = gli::FORMAT_COUNT; FormatIndex < FormatCount; ++FormatIndex) {
+					for (gli::size_t LayerIndex = 0, LayerCount = Textures[FormatIndex]->layers(); LayerIndex < LayerCount; ++LayerIndex) {
+						for (gli::size_t LevelIndex = 0, LevelCount = Textures[FormatIndex]->levels(); LevelIndex < LevelCount; ++LevelIndex) {
+							void* BaseAddress = Textures[FormatIndex]->data(LayerIndex, 0, LevelIndex);
+							Error += (BaseAddress != nullptr) ? 0 : 1;
+						}
+					}
 				}
 			}
 
 			std::clock_t TimeEnd = std::clock();
-
-			printf("Cube array texture data access performance test: %d\n", TimeEnd - TimeBegin);
+			std::cout << "Cube array texture data access performance test: " << TimeEnd - TimeBegin << std::endl;
 		}
 
 		{
 			std::clock_t TimeBegin = std::clock();
 
-			for(gli::size_t Index = 0, Count = Iterations; Index < Count; ++Index)
-			for(std::size_t FormatIndex = gli::FORMAT_FIRST, FormatCount = gli::FORMAT_COUNT; FormatIndex < FormatCount; ++FormatIndex)
-			{
-				for(gli::size_t LayerIndex = 0, LayerCount = Textures[FormatIndex]->layers(); LayerIndex < LayerCount; ++LayerIndex)
-				for(gli::size_t LevelIndex = 0, LevelCount = Textures[FormatIndex]->levels(); LevelIndex < LevelCount; ++LevelIndex)
-				{
-					gli::size_t Size = Textures[FormatIndex]->size(LevelIndex);
-					Error += Size != 0 ? 0 : 1;
+			for (gli::size_t Index = 0, Count = Iterations; Index < Count; ++Index) {
+				for (std::size_t FormatIndex = gli::FORMAT_FIRST, FormatCount = gli::FORMAT_COUNT; FormatIndex < FormatCount; ++FormatIndex) {
+					for (gli::size_t LayerIndex = 0, LayerCount = Textures[FormatIndex]->layers(); LayerIndex < LayerCount; ++LayerIndex) {
+						for (gli::size_t LevelIndex = 0, LevelCount = Textures[FormatIndex]->levels(); LevelIndex < LevelCount; ++LevelIndex) {
+							gli::size_t Size = Textures[FormatIndex]->size(LevelIndex);
+							Error += (Size != 0) ? 0 : 1;
+						}
+					}
 				}
 			}
 
 			std::clock_t TimeEnd = std::clock();
-
-			printf("Cube array texture size performance test: %d\n", TimeEnd - TimeBegin);
+			std::cout << "Cube array texture size performance test: " << TimeEnd - TimeBegin << std::endl;
 		}
 
 		{
 			std::clock_t TimeBegin = std::clock();
 
-			for(gli::size_t Index = 0, Count = Iterations; Index < Count; ++Index)
-			for(std::size_t FormatIndex = gli::FORMAT_FIRST, FormatCount = gli::FORMAT_COUNT; FormatIndex < FormatCount; ++FormatIndex)
-			{
-				for(gli::size_t LayerIndex = 0, LayerCount = Textures[FormatIndex]->layers(); LayerIndex < LayerCount; ++LayerIndex)
-				for(gli::size_t LevelIndex = 0, LevelCount = Textures[FormatIndex]->levels(); LevelIndex < LevelCount; ++LevelIndex)
-				{
-					gli::texture_cube_array::extent_type Extent = Textures[FormatIndex]->extent(LevelIndex);
-					Error += Extent.x != 0 ? 0 : 1;
-					Error += Extent.y != 0 ? 0 : 1;
+			for (gli::size_t Index = 0, Count = Iterations; Index < Count; ++Index) {
+				for (std::size_t FormatIndex = gli::FORMAT_FIRST, FormatCount = gli::FORMAT_COUNT; FormatIndex < FormatCount; ++FormatIndex) {
+					for (gli::size_t LayerIndex = 0, LayerCount = Textures[FormatIndex]->layers(); LayerIndex < LayerCount; ++LayerIndex) {
+						for(gli::size_t LevelIndex = 0, LevelCount = Textures[FormatIndex]->levels(); LevelIndex < LevelCount; ++LevelIndex) {
+							gli::texture_cube_array::extent_type Extent = Textures[FormatIndex]->extent(LevelIndex);
+							Error += (Extent.x != 0) ? 0 : 1;
+							Error += (Extent.y != 0) ? 0 : 1;
+						}
+					}
 				}
 			}
 
 			std::clock_t TimeEnd = std::clock();
-
-			printf("Cube array texture extent access performance test: %d\n", TimeEnd - TimeBegin);
+			std::cout << "Cube array texture extent access performance test: " << TimeEnd - TimeBegin << std::endl;
 		}
 
 		{
 			std::clock_t TimeBegin = std::clock();
 
-			for(gli::size_t Index = 0, Count = Iterations; Index < Count; ++Index)
-			for(std::size_t FormatIndex = gli::FORMAT_FIRST, FormatCount = gli::FORMAT_COUNT; FormatIndex < FormatCount; ++FormatIndex)
-			{
-				for(gli::size_t LayerIndex = 0, LayerCount = Textures[FormatIndex]->layers(); LayerIndex < LayerCount; ++LayerIndex)
-				for(gli::size_t LevelIndex = 0, LevelCount = Textures[FormatIndex]->levels(); LevelIndex < LevelCount; ++LevelIndex)
-				{
-					gli::texture_cube_array::extent_type Extent = Textures[FormatIndex]->extent(LevelIndex);
-					gli::size_t Size = Textures[FormatIndex]->size(LevelIndex);
+			for (gli::size_t Index = 0, Count = Iterations; Index < Count; ++Index) {
+				for (std::size_t FormatIndex = gli::FORMAT_FIRST, FormatCount = gli::FORMAT_COUNT; FormatIndex < FormatCount; ++FormatIndex) {
+					for (gli::size_t LayerIndex = 0, LayerCount = Textures[FormatIndex]->layers(); LayerIndex < LayerCount; ++LayerIndex) {
+						for (gli::size_t LevelIndex = 0, LevelCount = Textures[FormatIndex]->levels(); LevelIndex < LevelCount; ++LevelIndex) {
+							gli::texture_cube_array::extent_type Extent = Textures[FormatIndex]->extent(LevelIndex);
+							gli::size_t Size = Textures[FormatIndex]->size(LevelIndex);
 
-					Error += Extent.x != 0 ? 0 : 1;
-					Error += Extent.y != 0 ? 0 : 1;
-					Error += Size != 0 ? 0 : 1;
+							Error += (Extent.x != 0) ? 0 : 1;
+							Error += (Extent.y != 0) ? 0 : 1;
+							Error += (Size != 0) ? 0 : 1;
+						}
+					}
 				}
 			}
 
 			std::clock_t TimeEnd = std::clock();
-
-			printf("Cube array texture extent and size access performance test: %d\n", TimeEnd - TimeBegin);
+			std::cout << "Cube array texture extent and size access performance test: " << TimeEnd - TimeBegin << std::endl;
 		}
 
 		{
 			std::clock_t TimeBegin = std::clock();
 
-			for(gli::size_t Index = 0, Count = Iterations; Index < Count; ++Index)
-			for(std::size_t FormatIndex = gli::FORMAT_FIRST, FormatCount = gli::FORMAT_COUNT; FormatIndex < FormatCount; ++FormatIndex)
-			{
-				for(gli::size_t LayerIndex = 0, LayerCount = Textures[FormatIndex]->layers(); LayerIndex < LayerCount; ++LayerIndex)
-				for(gli::size_t LevelIndex = 0, LevelCount = Textures[FormatIndex]->levels(); LevelIndex < LevelCount; ++LevelIndex)
-				{
-					gli::texture_cube_array::extent_type Extent = Textures[FormatIndex]->extent(LevelIndex);
-					gli::size_t Size = Textures[FormatIndex]->size(LevelIndex);
-					void* BaseAddress = Textures[FormatIndex]->data(LayerIndex, 0, LevelIndex);
+			for (gli::size_t Index = 0, Count = Iterations; Index < Count; ++Index) {
+				for (std::size_t FormatIndex = gli::FORMAT_FIRST, FormatCount = gli::FORMAT_COUNT; FormatIndex < FormatCount; ++FormatIndex) {
+					for (gli::size_t LayerIndex = 0, LayerCount = Textures[FormatIndex]->layers(); LayerIndex < LayerCount; ++LayerIndex) {
+						for (gli::size_t LevelIndex = 0, LevelCount = Textures[FormatIndex]->levels(); LevelIndex < LevelCount; ++LevelIndex) {
+							gli::texture_cube_array::extent_type Extent = Textures[FormatIndex]->extent(LevelIndex);
+							gli::size_t Size = Textures[FormatIndex]->size(LevelIndex);
+							void* BaseAddress = Textures[FormatIndex]->data(LayerIndex, 0, LevelIndex);
 
-					Error += Extent.x != 0 ? 0 : 1;
-					Error += Extent.y != 0 ? 0 : 1;
-					Error += Size != 0 ? 0 : 1;
-					Error += BaseAddress != nullptr ? 0 : 1;
+							Error += (Extent.x != 0) ? 0 : 1;
+							Error += (Extent.y != 0) ? 0 : 1;
+							Error += (Size != 0) ? 0 : 1;
+							Error += (BaseAddress != nullptr) ? 0 : 1;
+						}
+					}
 				}
 			}
 
 			std::clock_t TimeEnd = std::clock();
-
-			printf("Cube array texture all access performance test: %d\n", TimeEnd - TimeBegin);
+			std::cout << "Cube array texture all access performance test: " << TimeEnd - TimeBegin << std::endl;
 		}
 
 		return Error;
 	}
-}//namespace perf_cube_array_access
+} // namespace perf_cube_array_access
 
-namespace perf_texture2d_access
-{
-	int main(std::size_t Iterations)
-	{
+namespace perf_texture2d_access {
+	int main(std::size_t Iterations) {
 		int Error = 0;
 
-		std::vector<std::shared_ptr<gli::texture2d> > Textures(gli::FORMAT_COUNT);
-		for(std::size_t FormatIndex = gli::FORMAT_FIRST, FormatCount = gli::FORMAT_COUNT; FormatIndex < FormatCount; ++FormatIndex)
-		{
-			Textures[FormatIndex].reset(new gli::texture2d(static_cast<gli::format>(FormatIndex), gli::texture2d::extent_type(4), 9));
+		std::vector<std::shared_ptr<gli::texture2d>> Textures(gli::FORMAT_COUNT);
+		for (std::size_t FormatIndex = gli::FORMAT_FIRST, FormatCount = gli::FORMAT_COUNT; FormatIndex < FormatCount; ++FormatIndex) {
+			Textures[FormatIndex].reset(new gli::texture2d(static_cast<gli::format>(FormatIndex), static_cast<gli::texture2d::extent_type>(4), 9));
 			Error += Textures[FormatIndex]->empty() ? 1 : 0;
 		}
 
 		{
 			std::clock_t TimeBegin = std::clock();
 
-			for(gli::size_t Index = 0, Count = Iterations; Index < Count; ++Index)
-			for(std::size_t FormatIndex = gli::FORMAT_FIRST, FormatCount = gli::FORMAT_COUNT; FormatIndex < FormatCount; ++FormatIndex)
-			{
-				for(gli::size_t LayerIndex = 0, LayerCount = Textures[FormatIndex]->layers(); LayerIndex < LayerCount; ++LayerIndex)
-				for(gli::size_t LevelIndex = 0, LevelCount = Textures[FormatIndex]->levels(); LevelIndex < LevelCount; ++LevelIndex)
-				{
-					void* BaseAddress = Textures[FormatIndex]->data(LayerIndex, 0, LevelIndex);
-					Error += BaseAddress != nullptr ? 0 : 1;
+			for (gli::size_t Index = 0, Count = Iterations; Index < Count; ++Index) {
+				for (std::size_t FormatIndex = gli::FORMAT_FIRST, FormatCount = gli::FORMAT_COUNT; FormatIndex < FormatCount; ++FormatIndex) {
+					for (gli::size_t LayerIndex = 0, LayerCount = Textures[FormatIndex]->layers(); LayerIndex < LayerCount; ++LayerIndex) {
+						for (gli::size_t LevelIndex = 0, LevelCount = Textures[FormatIndex]->levels(); LevelIndex < LevelCount; ++LevelIndex) {
+							void* BaseAddress = Textures[FormatIndex]->data(LayerIndex, 0, LevelIndex);
+							Error += (BaseAddress != nullptr) ? 0 : 1;
+						}
+					}
 				}
 			}
 
 			std::clock_t TimeEnd = std::clock();
-
-			printf("2d texture data access performance test: %d\n", TimeEnd - TimeBegin);
+			std::cout << "2d texture data access performance test: " << TimeEnd - TimeBegin << std::endl;
 		}
 
 		{
 			std::clock_t TimeBegin = std::clock();
 
-			for(gli::size_t Index = 0, Count = Iterations; Index < Count; ++Index)
-			for(std::size_t FormatIndex = gli::FORMAT_FIRST, FormatCount = gli::FORMAT_COUNT; FormatIndex < FormatCount; ++FormatIndex)
-			{
-				for(gli::size_t LayerIndex = 0, LayerCount = Textures[FormatIndex]->layers(); LayerIndex < LayerCount; ++LayerIndex)
-				for(gli::size_t LevelIndex = 0, LevelCount = Textures[FormatIndex]->levels(); LevelIndex < LevelCount; ++LevelIndex)
-				{
-					gli::size_t Size = Textures[FormatIndex]->size(LevelIndex);
-					Error += Size != 0 ? 0 : 1;
+			for (gli::size_t Index = 0, Count = Iterations; Index < Count; ++Index) {
+				for (std::size_t FormatIndex = gli::FORMAT_FIRST, FormatCount = gli::FORMAT_COUNT; FormatIndex < FormatCount; ++FormatIndex) {
+					for (gli::size_t LayerIndex = 0, LayerCount = Textures[FormatIndex]->layers(); LayerIndex < LayerCount; ++LayerIndex) {
+						for (gli::size_t LevelIndex = 0, LevelCount = Textures[FormatIndex]->levels(); LevelIndex < LevelCount; ++LevelIndex) {
+							gli::size_t Size = Textures[FormatIndex]->size(LevelIndex);
+							Error += (Size != 0) ? 0 : 1;
+						}
+					}
 				}
 			}
 
 			std::clock_t TimeEnd = std::clock();
-
-			printf("2d texture size performance test: %d\n", TimeEnd - TimeBegin);
+			std::cout << "2d texture size performance test: " << TimeEnd - TimeBegin << std::endl;
 		}
 
 		{
 			std::clock_t TimeBegin = std::clock();
 
-			for(gli::size_t Index = 0, Count = Iterations; Index < Count; ++Index)
-			for(std::size_t FormatIndex = gli::FORMAT_FIRST, FormatCount = gli::FORMAT_COUNT; FormatIndex < FormatCount; ++FormatIndex)
-			{
-				for(gli::size_t LayerIndex = 0, LayerCount = Textures[FormatIndex]->layers(); LayerIndex < LayerCount; ++LayerIndex)
-				for(gli::size_t LevelIndex = 0, LevelCount = Textures[FormatIndex]->levels(); LevelIndex < LevelCount; ++LevelIndex)
-				{
-					gli::texture2d::extent_type Extent = Textures[FormatIndex]->extent(LevelIndex);
-					Error += Extent.x != 0 ? 0 : 1;
-					Error += Extent.y != 0 ? 0 : 1;
+			for (gli::size_t Index = 0, Count = Iterations; Index < Count; ++Index) {
+				for (std::size_t FormatIndex = gli::FORMAT_FIRST, FormatCount = gli::FORMAT_COUNT; FormatIndex < FormatCount; ++FormatIndex) {
+					for (gli::size_t LayerIndex = 0, LayerCount = Textures[FormatIndex]->layers(); LayerIndex < LayerCount; ++LayerIndex) {
+						for (gli::size_t LevelIndex = 0, LevelCount = Textures[FormatIndex]->levels(); LevelIndex < LevelCount; ++LevelIndex) {
+							gli::texture2d::extent_type Extent = Textures[FormatIndex]->extent(LevelIndex);
+							Error += (Extent.x != 0) ? 0 : 1;
+							Error += (Extent.y != 0) ? 0 : 1;
+						}
+					}
 				}
 			}
 
 			std::clock_t TimeEnd = std::clock();
-
-			printf("2d texture extent access performance test: %d\n", TimeEnd - TimeBegin);
+			std::cout << "2d texture extent access performance test: " << TimeEnd - TimeBegin << std::endl;
 		}
 
 		{
 			std::clock_t TimeBegin = std::clock();
 
-			for(gli::size_t Index = 0, Count = Iterations; Index < Count; ++Index)
-			for(std::size_t FormatIndex = gli::FORMAT_FIRST, FormatCount = gli::FORMAT_COUNT; FormatIndex < FormatCount; ++FormatIndex)
-			{
-				for(gli::size_t LayerIndex = 0, LayerCount = Textures[FormatIndex]->layers(); LayerIndex < LayerCount; ++LayerIndex)
-				for(gli::size_t LevelIndex = 0, LevelCount = Textures[FormatIndex]->levels(); LevelIndex < LevelCount; ++LevelIndex)
-				{
-					gli::texture2d::extent_type Extent = Textures[FormatIndex]->extent(LevelIndex);
-					gli::size_t Size = Textures[FormatIndex]->size(LevelIndex);
+			for (gli::size_t Index = 0, Count = Iterations; Index < Count; ++Index) {
+				for (std::size_t FormatIndex = gli::FORMAT_FIRST, FormatCount = gli::FORMAT_COUNT; FormatIndex < FormatCount; ++FormatIndex) {
+					for (gli::size_t LayerIndex = 0, LayerCount = Textures[FormatIndex]->layers(); LayerIndex < LayerCount; ++LayerIndex) {
+						for (gli::size_t LevelIndex = 0, LevelCount = Textures[FormatIndex]->levels(); LevelIndex < LevelCount; ++LevelIndex) {
+							gli::texture2d::extent_type Extent = Textures[FormatIndex]->extent(LevelIndex);
+							gli::size_t Size = Textures[FormatIndex]->size(LevelIndex);
 
-					Error += Extent.x != 0 ? 0 : 1;
-					Error += Extent.y != 0 ? 0 : 1;
-					Error += Size != 0 ? 0 : 1;
+							Error += (Extent.x != 0) ? 0 : 1;
+							Error += (Extent.y != 0) ? 0 : 1;
+							Error += (Size != 0) ? 0 : 1;
+						}
+					}
 				}
 			}
 
 			std::clock_t TimeEnd = std::clock();
-
-			printf("2d texture extent and size access performance test: %d\n", TimeEnd - TimeBegin);
+			std::cout << "2d texture extent and size access performance test: " << TimeEnd - TimeBegin << std::endl;
 		}
 
 		{
 			std::clock_t TimeBegin = std::clock();
 
-			for(gli::size_t Index = 0, Count = Iterations; Index < Count; ++Index)
-			for(std::size_t FormatIndex = gli::FORMAT_FIRST, FormatCount = gli::FORMAT_COUNT; FormatIndex < FormatCount; ++FormatIndex)
-			{
-				for(gli::size_t LayerIndex = 0, LayerCount = Textures[FormatIndex]->layers(); LayerIndex < LayerCount; ++LayerIndex)
-				for(gli::size_t LevelIndex = 0, LevelCount = Textures[FormatIndex]->levels(); LevelIndex < LevelCount; ++LevelIndex)
-				{
-					gli::texture2d::extent_type Extent = Textures[FormatIndex]->extent(LevelIndex);
-					gli::size_t Size = Textures[FormatIndex]->size(LevelIndex);
-					void* BaseAddress = Textures[FormatIndex]->data(LayerIndex, 0, LevelIndex);
+			for (gli::size_t Index = 0, Count = Iterations; Index < Count; ++Index) {
+				for (std::size_t FormatIndex = gli::FORMAT_FIRST, FormatCount = gli::FORMAT_COUNT; FormatIndex < FormatCount; ++FormatIndex) {
+					for (gli::size_t LayerIndex = 0, LayerCount = Textures[FormatIndex]->layers(); LayerIndex < LayerCount; ++LayerIndex) {
+						for (gli::size_t LevelIndex = 0, LevelCount = Textures[FormatIndex]->levels(); LevelIndex < LevelCount; ++LevelIndex) {
+							gli::texture2d::extent_type Extent = Textures[FormatIndex]->extent(LevelIndex);
+							gli::size_t Size = Textures[FormatIndex]->size(LevelIndex);
+							void* BaseAddress = Textures[FormatIndex]->data(LayerIndex, 0, LevelIndex);
 
-					Error += Extent.x != 0 ? 0 : 1;
-					Error += Extent.y != 0 ? 0 : 1;
-					Error += Size != 0 ? 0 : 1;
-					Error += BaseAddress != nullptr ? 0 : 1;
+							Error += (Extent.x != 0) ? 0 : 1;
+							Error += (Extent.y != 0) ? 0 : 1;
+							Error += (Size != 0) ? 0 : 1;
+							Error += (BaseAddress != nullptr) ? 0 : 1;
+						}
+					}
 				}
 			}
 
 			std::clock_t TimeEnd = std::clock();
-
-			printf("2d texture all access performance test: %d\n", TimeEnd - TimeBegin);
+			std::cout << "2d texture all access performance test: " << TimeEnd - TimeBegin << std::endl;
 		}
 
 		return Error;
 	}
-}//namespace perf_texture2d_access
+} // namespace perf_texture2d_access
 
-namespace perf_texture_load
-{
-	int main(int Extent)
-	{
+namespace perf_texture_load {
+	int main(int Extent) {
 		int Error = 0;
 
-		gli::texture2d Texture(gli::FORMAT_R8_UNORM_PACK8, gli::texture2d::extent_type(Extent));
-		Texture.clear(gli::u8(255));
+		gli::texture2d Texture(gli::FORMAT_R8_UNORM_PACK8, static_cast<gli::texture2d::extent_type>(Extent));
+		Texture.clear(static_cast<gli::u8>(255));
 
 		std::clock_t TimeBegin = std::clock();
 
-		for(gli::texture2d::size_type LevelIndex = 0, LevelCount = Texture.levels(); LevelIndex < LevelCount; ++LevelIndex)
-		{
-			gli::texture2d::extent_type const Extent = Texture.extent(LevelIndex);
-			for(gli::size_t y = 0; y < Extent.y; ++y)
-			for(gli::size_t x = 0; x < Extent.x; ++x)
-			{
-				gli::u8 Texel = Texture.load<gli::u8>(gli::texture2d::extent_type(x, y), LevelIndex);
-				Error += Texel == gli::u8(255) ? 0 : 1;
+		for (gli::texture2d::size_type LevelIndex = 0, LevelCount = Texture.levels(); LevelIndex < LevelCount; ++LevelIndex) {
+			const gli::texture2d::extent_type Extent = Texture.extent(LevelIndex);
+			for (gli::size_t y = 0; y < Extent.y; ++y) {
+				for (gli::size_t x = 0; x < Extent.x; ++x) {
+					gli::u8 Texel = Texture.load<gli::u8>(gli::texture2d::extent_type(x, y), LevelIndex);
+					Error += (Texel == static_cast<gli::u8>(255)) ? 0 : 1;
+				}
 			}
 		}
 
 		std::clock_t TimeEnd = std::clock();
-		printf("2D texture load performance test: %d\n", TimeEnd - TimeBegin);
+		std::cout << "2D texture load performance test: " << TimeEnd - TimeBegin << std::endl;
 
 		return Error;
 	}
-}//namespace perf_texture_load
+} // namespace perf_texture_load
 
-namespace perf_texture_fetch
-{
-	int main(int Extent)
-	{
+namespace perf_texture_fetch {
+	int main(int Extent) {
 		int Error = 0;
 
-		gli::texture2d Texture(gli::FORMAT_R8_UNORM_PACK8, gli::texture2d::extent_type(Extent));
-		Texture.clear(gli::u8(255));
+		gli::texture2d Texture(gli::FORMAT_R8_UNORM_PACK8, static_cast<gli::texture2d::extent_type>(Extent));
+		Texture.clear(static_cast<gli::u8>(255));
 
 		gli::sampler2d<float> Sampler(Texture, gli::WRAP_CLAMP_TO_EDGE);
 
 		std::clock_t TimeBegin = std::clock();
 
-		for(gli::texture2d::size_type LevelIndex = 0, LevelCount = Texture.levels(); LevelIndex < LevelCount; ++LevelIndex)
-		{
-			gli::texture2d::extent_type const Extent = Texture.extent(LevelIndex);
-			for(gli::size_t y = 0; y < Extent.y; ++y)
-			for(gli::size_t x = 0; x < Extent.x; ++x)
-			{
-				gli::vec4 const& Texel = Sampler.texel_fetch(gli::texture2d::extent_type(x, y), LevelIndex);
-				Error += gli::all(gli::epsilonEqual(Texel, gli::vec4(1, 0, 0, 1), 0.001f)) ? 0 : 1;
-				assert(!Error);
+		for (gli::texture2d::size_type LevelIndex = 0, LevelCount = Texture.levels(); LevelIndex < LevelCount; ++LevelIndex) {
+			const gli::texture2d::extent_type Extent = Texture.extent(LevelIndex);
+			for (gli::size_t y = 0; y < Extent.y; ++y) {
+				for (gli::size_t x = 0; x < Extent.x; ++x) {
+					const gli::vec4& Texel = Sampler.texel_fetch(gli::texture2d::extent_type(x, y), LevelIndex);
+					Error += gli::all(gli::epsilonEqual(Texel, gli::vec4(1, 0, 0, 1), 0.001f)) ? 0 : 1;
+					assert(!Error);
+				}
 			}
 		}
 
 		std::clock_t TimeEnd = std::clock();
-		printf("2D texture fetch performance test: %d\n", TimeEnd - TimeBegin);
+		std::cout << "2D texture fetch performance test: " << TimeEnd - TimeBegin << std::endl;
 
 		return Error;
 	}
-}//namespace perf_texture_fetch
+} // namespace perf_texture_fetch
 
-namespace perf_texture_lod_nearest
-{
-	int main(int Extent)
-	{
+namespace perf_texture_lod_nearest {
+	int main(int Extent) {
 		int Error = 0;
 
-		gli::texture2d Texture(gli::FORMAT_R8_UNORM_PACK8, gli::texture2d::extent_type(Extent));
-		Texture.clear(gli::u8(255));
+		gli::texture2d Texture(gli::FORMAT_R8_UNORM_PACK8, static_cast<gli::texture2d::extent_type>(Extent));
+		Texture.clear(static_cast<gli::u8>(255));
 
 		gli::sampler2d<float> Sampler(Texture, gli::WRAP_CLAMP_TO_EDGE, gli::FILTER_NEAREST, gli::FILTER_NEAREST);
 
 		std::clock_t TimeBegin = std::clock();
 
-		for(gli::texture2d::size_type LevelIndex = 0, LevelCount = Texture.levels(); LevelIndex < LevelCount; ++LevelIndex)
-		{
-			gli::texture2d::extent_type const Extent = Texture.extent(LevelIndex);
-			for(gli::size_t y = 0; y < Extent.y; ++y)
-			for(gli::size_t x = 0; x < Extent.x; ++x)
-			{
-				gli::vec4 const& Texel = Sampler.texture_lod(glm::vec2(x, y) / glm::vec2(Extent), static_cast<float>(LevelIndex));
-				Error += gli::all(gli::epsilonEqual(Texel, gli::vec4(1, 0, 0, 1), 0.001f)) ? 0 : 1;
+		for (gli::texture2d::size_type LevelIndex = 0, LevelCount = Texture.levels(); LevelIndex < LevelCount; ++LevelIndex) {
+			const gli::texture2d::extent_type Extent = Texture.extent(LevelIndex);
+			for (gli::size_t y = 0; y < Extent.y; ++y) {
+				for (gli::size_t x = 0; x < Extent.x; ++x) {
+					const gli::vec4& Texel = Sampler.texture_lod(glm::vec2(x, y) / glm::vec2(Extent), static_cast<float>(LevelIndex));
+					Error += gli::all(gli::epsilonEqual(Texel, gli::vec4(1, 0, 0, 1), 0.001f)) ? 0 : 1;
+				}
 			}
 		}
 
 		std::clock_t TimeEnd = std::clock();
-		printf("2D texture lod nearest performance test: %d\n", TimeEnd - TimeBegin);
+		std::cout << "2D texture lod nearest performance test: " << TimeEnd - TimeBegin << std::endl;
 
 		return Error;
 	}
-}//namespace perf_texture_lod_nearest
+} // namespace perf_texture_lod_nearest
 
-namespace perf_texture_lod_linear
-{
-	int main(int Extent)
-	{
+namespace perf_texture_lod_linear {
+	int main(int Extent) {
 		int Error = 0;
 
-		gli::texture2d Texture(gli::FORMAT_R8_UNORM_PACK8, gli::texture2d::extent_type(Extent));
-		Texture.clear(gli::u8(255));
+		gli::texture2d Texture(gli::FORMAT_R8_UNORM_PACK8, static_cast<gli::texture2d::extent_type>(Extent));
+		Texture.clear(static_cast<gli::u8>(255));
 
 		gli::sampler2d<float> Sampler(Texture, gli::WRAP_CLAMP_TO_EDGE, gli::FILTER_NEAREST, gli::FILTER_LINEAR);
 
 		std::clock_t TimeBegin = std::clock();
 
-		for(gli::texture2d::size_type LevelIndex = 0, LevelCount = Texture.levels(); LevelIndex < LevelCount; ++LevelIndex)
-		{
-			gli::texture2d::extent_type const Extent = Texture.extent(LevelIndex);
-			for(gli::size_t y = 0; y < Extent.y; ++y)
-			for(gli::size_t x = 0; x < Extent.x; ++x)
-			{
-				gli::vec4 const& Texel = Sampler.texture_lod(glm::vec2(x, y) / glm::vec2(Extent), static_cast<float>(LevelIndex));
-				Error += gli::all(gli::epsilonEqual(Texel, gli::vec4(1, 0, 0, 1), 0.001f)) ? 0 : 1;
+		for (gli::texture2d::size_type LevelIndex = 0, LevelCount = Texture.levels(); LevelIndex < LevelCount; ++LevelIndex) {
+			const gli::texture2d::extent_type Extent = Texture.extent(LevelIndex);
+			for (gli::size_t y = 0; y < Extent.y; ++y) {
+				for (gli::size_t x = 0; x < Extent.x; ++x) {
+					const gli::vec4& Texel = Sampler.texture_lod(glm::vec2(x, y) / glm::vec2(Extent), static_cast<float>(LevelIndex));
+					Error += gli::all(gli::epsilonEqual(Texel, gli::vec4(1, 0, 0, 1), 0.001f)) ? 0 : 1;
+				}
 			}
 		}
 
 		std::clock_t TimeEnd = std::clock();
-		printf("2D texture lod linear performance test: %d\n", TimeEnd - TimeBegin);
+		std::cout << "2D texture lod linear performance test: " << TimeEnd - TimeBegin << std::endl;
 
 		return Error;
 	}
-}//namespace perf_texture_lod_linear
+} // namespace perf_texture_lod_linear
 
-namespace perf_generate_mipmaps_nearest
-{
-	int main(int Extent)
-	{
+namespace perf_generate_mipmaps_nearest {
+	int main(int Extent) {
 		int Error = 0;
 
-		gli::texture2d TextureSource(gli::FORMAT_R8_UNORM_PACK8, gli::texture2d::extent_type(Extent));
-		TextureSource.clear(gli::u8(255));
+		gli::texture2d TextureSource(gli::FORMAT_R8_UNORM_PACK8, static_cast<gli::texture2d::extent_type>(Extent));
+		TextureSource.clear(static_cast<gli::u8>(255));
 
 		std::clock_t TimeBegin = std::clock();
 
 		gli::texture2d TextureMipmaps = gli::generate_mipmaps(TextureSource, gli::FILTER_NEAREST);
-		Error = *TextureMipmaps.data<glm::u8>(0, 0, TextureMipmaps.max_level()) == gli::u8(255) ? 0 : 1;
+		Error = (*TextureMipmaps.data<glm::u8>(0, 0, TextureMipmaps.max_level()) == gli::u8(255)) ? 0 : 1;
 
 		std::clock_t TimeEnd = std::clock();
-
-		printf("2D texture generate mipmaps nearest performance test: %d\n", TimeEnd - TimeBegin);
+		std::cout << "2D texture generate mipmaps nearest performance test: " << TimeEnd - TimeBegin << std::endl;
 
 		return Error;
 	}
-}//namespace perf_generate_mipmaps_nearest
+} // namespace perf_generate_mipmaps_nearest
 
-namespace perf_generate_mipmaps_linear
-{
-	int main(int Extent)
-	{
+namespace perf_generate_mipmaps_linear {
+	int main(int Extent) {
 		int Error = 0;
 
-		gli::texture2d TextureSource(gli::FORMAT_R8_UNORM_PACK8, gli::texture2d::extent_type(Extent));
-		TextureSource.clear(gli::u8(255));
+		gli::texture2d TextureSource(gli::FORMAT_R8_UNORM_PACK8, static_cast<gli::texture2d::extent_type>(Extent));
+		TextureSource.clear(static_cast<gli::u8>(255));
 
 		std::clock_t TimeBegin = std::clock();
 
 		gli::texture2d TextureMipmaps = gli::generate_mipmaps(TextureSource, gli::FILTER_LINEAR);
-		Error = *TextureMipmaps.data<glm::u8>(0, 0, TextureMipmaps.max_level()) == gli::u8(255) ? 0 : 1;
+		Error = (*TextureMipmaps.data<glm::u8>(0, 0, TextureMipmaps.max_level()) == gli::u8(255)) ? 0 : 1;
 
 		std::clock_t TimeEnd = std::clock();
-
-		printf("2D texture generate mipmaps linear performance test: %d\n", TimeEnd - TimeBegin);
+		std::cout << "2D texture generate mipmaps linear performance test: " << TimeEnd - TimeBegin << std::endl;
 
 		return Error;
 	}
-}//namespace perf_generate_mipmaps_linear
+} // namespace perf_generate_mipmaps_linear
 
-int main()
-{
+int main() {
 	int Error = 0;
 
-	bool const DO_PERF_TEST = false;
+	const bool DO_PERF_TEST = false;
 
-	std::size_t const PERF_TEST_ACCESS_ITERATION = DO_PERF_TEST ? 100000 : 0;
-	std::size_t const PERF_TEST_CREATION_ITERATION = DO_PERF_TEST ? 1000 : 0;
+	const std::size_t PERF_TEST_ACCESS_ITERATION = DO_PERF_TEST ? 100000 : 0;
+	const std::size_t PERF_TEST_CREATION_ITERATION = DO_PERF_TEST ? 1000 : 0;
 
 	Error += perf_texture_load::main(DO_PERF_TEST ? 8192 : 1024);
 	Error += perf_texture_fetch::main(DO_PERF_TEST ? 8192 : 1024);

--- a/test/core/test_duplicate.cpp
+++ b/test/core/test_duplicate.cpp
@@ -1,102 +1,88 @@
+#include <vector>
+
 #include <gli/duplicate.hpp>
 #include <gli/view.hpp>
 #include <gli/comparison.hpp>
 
-int test_texture1D
-(
-	std::vector<gli::format> const & Formats, 
-	gli::texture1d::extent_type const & TextureSize
-)
-{
-	int Error(0);
+int test_texture1D(const std::vector<gli::format>& Formats, const gli::texture1d::extent_type& TextureSize) {
+	int Error = 0;
 
-	for(std::size_t i = 0; i < Formats.size(); ++i)
-	{
-		gli::texture1d TextureA(
-			Formats[i],
-			TextureSize,
-			gli::levels(TextureSize));
+	for (const auto& Format: Formats) {
+		gli::texture1d TextureA(Format, TextureSize, gli::levels(TextureSize));
 
 		gli::texture1d TextureB(gli::duplicate(TextureA));
 
-		Error += TextureA == TextureB ? 0 : 1;
+		Error += (TextureA == TextureB) ? 0 : 1;
 
 		gli::texture1d TextureC(TextureA, gli::texture1d::size_type(1), gli::texture1d::size_type(2));
 
-		Error += TextureA[1] == TextureC[0] ? 0 : 1;
-		Error += TextureA[2] == TextureC[1] ? 0 : 1;
+		Error += (TextureA[1] == TextureC[0]) ? 0 : 1;
+		Error += (TextureA[2] == TextureC[1]) ? 0 : 1;
 
 		gli::texture1d TextureD(gli::duplicate(TextureC));
 
-		Error += TextureC == TextureD ? 0 : 1;
+		Error += (TextureC == TextureD) ? 0 : 1;
 
 		gli::texture1d TextureG(gli::duplicate(TextureA, 0, TextureA.levels() - 1));
-		Error += TextureA == TextureG ? 0 : 1;
+		Error += (TextureA == TextureG) ? 0 : 1;
 
 		gli::texture1d TextureE(gli::duplicate(TextureA, 1, TextureA.levels() - 2));
-		Error += TextureA[1] == TextureE[0] ? 0 : 1;
+		Error += (TextureA[1] == TextureE[0]) ? 0 : 1;
 
 		gli::texture1d TextureF(TextureA, 1, TextureA.levels() - 2);
 
-		Error += TextureE == TextureF ? 0 : 1;
+		Error += (TextureE == TextureF) ? 0 : 1;
 	}
 
 	return Error;
 }
 
-int test_texture1DArray
-(
-	std::vector<gli::format> const & Formats,
-	gli::texture1d::extent_type const & TextureSize
-)
-{
-	int Error(0);
+int test_texture1DArray(const std::vector<gli::format>& Formats, const gli::texture1d::extent_type& TextureSize) {
+	int Error = 0;
 
-	for(std::size_t i = 0; i < Formats.size(); ++i)
-	{
-		gli::texture1d_array TextureA(
-			Formats[i],
-			TextureSize,
-			gli::texture1d_array::size_type(4));
+	for (const auto& Format: Formats) {
+		gli::texture1d_array TextureA(Format, TextureSize, gli::texture1d_array::size_type(4));
 
 		gli::texture1d_array TextureB(gli::duplicate(TextureA));
 
-		Error += TextureA == TextureB ? 0 : 1;
+		Error += (TextureA == TextureB) ? 0 : 1;
 
 		gli::texture1d_array TextureC(TextureA,
-			gli::texture1d_array::size_type(0), TextureA.layers() - 1,
-			gli::texture1d_array::size_type(1), gli::texture1d_array::size_type(2));
+			gli::texture1d_array::size_type(0),
+			TextureA.layers() - 1,
+			gli::texture1d_array::size_type(1),
+			gli::texture1d_array::size_type(2));
 
-		Error += TextureA[0][1] == TextureC[0][0] ? 0 : 1;
-		Error += TextureA[0][2] == TextureC[0][1] ? 0 : 1;
-		Error += TextureA[1][1] == TextureC[1][0] ? 0 : 1;
-		Error += TextureA[1][2] == TextureC[1][1] ? 0 : 1;
+		Error += (TextureA[0][1] == TextureC[0][0]) ? 0 : 1;
+		Error += (TextureA[0][2] == TextureC[0][1]) ? 0 : 1;
+		Error += (TextureA[1][1] == TextureC[1][0]) ? 0 : 1;
+		Error += (TextureA[1][2] == TextureC[1][1]) ? 0 : 1;
 
 		gli::texture1d_array TextureD(gli::duplicate(TextureC));
 
-		Error += TextureC == TextureD ? 0 : 1;
+		Error += (TextureC == TextureD) ? 0 : 1;
 
 		gli::texture1d_array TextureG(gli::duplicate(
 			TextureA,
 			0, TextureA.layers() - 1,
 			0, TextureA.levels() - 1));
-		Error += TextureA == TextureG ? 0 : 1;
+		Error += (TextureA == TextureG) ? 0 : 1;
 
 		gli::texture1d_array TextureE(gli::duplicate(
 			TextureA,
 			1, TextureA.layers() - 1,
 			0, TextureA.levels() - 1));
-		Error += TextureA[1] == TextureE[0] ? 0 : 1;
+		Error += (TextureA[1] == TextureE[0]) ? 0 : 1;
 
 		gli::texture1d_array TextureF(
 			TextureA, 
 			1, TextureA.layers() - 1, 
 			0, TextureA.levels() - 1); 
 
-		Error += TextureE == TextureF ? 0 : 1;
+		Error += (TextureE == TextureF) ? 0 : 1;
 
 		gli::texture1d_array TextureK(
-			Formats[i],
+			Format,
 			TextureSize,
 			gli::texture1d_array::size_type(4),
 			gli::levels(TextureSize));
@@ -104,310 +90,289 @@ int test_texture1DArray
 		gli::texture1d_array TextureH(TextureK, 1, 2, 1, 2);
 		gli::texture1d_array TextureI(gli::duplicate(TextureH));
 
-		Error += TextureH == TextureI ? 0 : 1;
+		Error += (TextureH == TextureI) ? 0 : 1;
 
 		gli::texture1d_array TextureJ(gli::duplicate(TextureK, 1, 2, 1, 2));
-		Error += TextureH == TextureJ ? 0 : 1;
-		Error += TextureI == TextureJ ? 0 : 1;
+		Error += (TextureH == TextureJ) ? 0 : 1;
+		Error += (TextureI == TextureJ) ? 0 : 1;
 	}
 
 	return Error;
 }
 
-int test_texture2D
-(
-	std::vector<gli::format> const & Formats, 
-	gli::texture2d::extent_type const & TextureSize
-)
-{
-	int Error(0);
+int test_texture2D(const std::vector<gli::format>& Formats, const gli::texture2d::extent_type& TextureSize) {
+	int Error = 0;
 
-	for(std::size_t i = 0; i < Formats.size(); ++i)
-	{
-		gli::texture2d TextureA(Formats[i], TextureSize);
+	for (const auto& Format: Formats) {
+		gli::texture2d TextureA(Format, TextureSize);
 
 		gli::texture2d TextureB(gli::duplicate(TextureA));
-		Error += TextureA == TextureB ? 0 : 1;
+		Error += (TextureA == TextureB) ? 0 : 1;
 
 		gli::texture2d TextureC(gli::view(
-			TextureA, gli::texture2d::size_type(1), gli::texture2d::size_type(2)));
+			TextureA, gli::texture2d::size_type(1),
+			gli::texture2d::size_type(2)));
 
-		Error += TextureA[1] == TextureC[0] ? 0 : 1;
-		Error += TextureA[2] == TextureC[1] ? 0 : 1;
+		Error += (TextureA[1] == TextureC[0]) ? 0 : 1;
+		Error += (TextureA[2] == TextureC[1]) ? 0 : 1;
 
 		gli::texture2d TextureD(gli::duplicate(TextureC));
 
-		Error += TextureC == TextureD ? 0 : 1;
+		Error += (TextureC == TextureD) ? 0 : 1;
 
 		gli::texture2d TextureG(gli::duplicate(TextureA, 0, TextureA.levels() - 1));
-		Error += TextureA == TextureG ? 0 : 1;
+		Error += (TextureA == TextureG) ? 0 : 1;
 
 		gli::texture2d TextureE(gli::duplicate(TextureA, 1, TextureA.levels() - 1));
-		Error += TextureA[1] == TextureE[0] ? 0 : 1;
+		Error += (TextureA[1] == TextureE[0]) ? 0 : 1;
 
-		gli::texture2d TextureF(gli::view(
-			TextureA, 1, TextureA.levels() - 1));
+		gli::texture2d TextureF(gli::view(TextureA, 1, TextureA.levels() - 1));
 
-		Error += TextureE == TextureF ? 0 : 1;
+		Error += (TextureE == TextureF) ? 0 : 1;
 	}
 
 	return Error;
 }
 
-int test_texture2DArray
-(
-	std::vector<gli::format> const & Formats,
-	gli::texture2d_array::extent_type const & TextureSize
-)
-{
-	int Error(0);
+int test_texture2DArray(const std::vector<gli::format>& Formats, const gli::texture2d_array::extent_type& TextureSize) {
+	int Error = 0;
 
-	for(std::size_t i = 0; i < Formats.size(); ++i)
-	{
+	for (const auto& Format: Formats) {
 		gli::texture2d_array TextureA(
-			Formats[i],
+			Format,
 			TextureSize,
 			gli::texture2d_array::size_type(4));
 
 		gli::texture2d_array TextureB(gli::duplicate(TextureA));
 
-		Error += TextureA == TextureB ? 0 : 1;
+		Error += (TextureA == TextureB) ? 0 : 1;
 
 		gli::texture2d_array TextureC(TextureA,
-			gli::texture2d_array::size_type(0), TextureA.layers() - 1,
-			gli::texture2d_array::size_type(1), gli::texture2d_array::size_type(2));
+			gli::texture2d_array::size_type(0),
+			TextureA.layers() - 1,
+			gli::texture2d_array::size_type(1),
+			gli::texture2d_array::size_type(2));
 
-		Error += TextureA[0][1] == TextureC[0][0] ? 0 : 1;
-		Error += TextureA[0][2] == TextureC[0][1] ? 0 : 1;
-		Error += TextureA[1][1] == TextureC[1][0] ? 0 : 1;
-		Error += TextureA[1][2] == TextureC[1][1] ? 0 : 1;
+		Error += (TextureA[0][1] == TextureC[0][0]) ? 0 : 1;
+		Error += (TextureA[0][2] == TextureC[0][1]) ? 0 : 1;
+		Error += (TextureA[1][1] == TextureC[1][0]) ? 0 : 1;
+		Error += (TextureA[1][2] == TextureC[1][1]) ? 0 : 1;
 
 		gli::texture2d_array TextureD(gli::duplicate(TextureC));
 
-		Error += TextureC == TextureD ? 0 : 1;
+		Error += (TextureC == TextureD) ? 0 : 1;
 
 		gli::texture2d_array TextureG(gli::duplicate(
 			TextureA,
 			0, TextureA.layers() - 1,
 			0, TextureA.levels() - 1));
-		Error += TextureA == TextureG ? 0 : 1;
+		Error += (TextureA == TextureG) ? 0 : 1;
 
 		gli::texture2d_array TextureE(gli::duplicate(
 			TextureA,
 			1, TextureA.layers() - 1,
 			0, TextureA.levels() - 1));
-		Error += TextureA[1] == TextureE[0] ? 0 : 1;
+		Error += (TextureA[1] == TextureE[0]) ? 0 : 1;
 
 		gli::texture2d_array TextureF(
 			TextureA,
 			1, TextureA.layers() - 1,
 			0, TextureA.levels() - 1);
 
-		Error += TextureE == TextureF ? 0 : 1;
+		Error += (TextureE == TextureF) ? 0 : 1;
 
 		gli::texture2d_array TextureK(
-			Formats[i],
+			Format,
 			TextureSize,
 			gli::texture2d_array::size_type(4));
 
 		gli::texture2d_array TextureH(TextureK, 1, 2, 1, 2);
 		gli::texture2d_array TextureI(gli::duplicate(TextureH));
 
-		Error += TextureH == TextureI ? 0 : 1;
+		Error += (TextureH == TextureI) ? 0 : 1;
 
 		gli::texture2d_array TextureJ(gli::duplicate(TextureK, 1, 2, 1, 2));
-		Error += TextureH == TextureJ ? 0 : 1;
-		Error += TextureI == TextureJ ? 0 : 1;
+		Error += (TextureH == TextureJ) ? 0 : 1;
+		Error += (TextureI == TextureJ) ? 0 : 1;
 	}
 
 	return Error;
 }
 
-int test_texture3D
-(
-	std::vector<gli::format> const & Formats, 
-	gli::texture3d::extent_type const & TextureSize
-)
-{
-	int Error(0);
+int test_texture3D(const std::vector<gli::format>& Formats, const gli::texture3d::extent_type& TextureSize) {
+	int Error = 0;
 
-	for(std::size_t i = 0; i < Formats.size(); ++i)
-	{
-		gli::texture3d TextureA(Formats[i], TextureSize);
+	for (const auto& Format: Formats) {
+		gli::texture3d TextureA(Format, TextureSize);
 
 		gli::texture3d TextureB(gli::duplicate(TextureA));
 
-		Error += TextureA == TextureB ? 0 : 1;
+		Error += (TextureA == TextureB) ? 0 : 1;
 
 		gli::texture3d TextureC(TextureA, gli::texture3d::size_type(1), gli::texture3d::size_type(2));
 
-		Error += TextureA[1] == TextureC[0] ? 0 : 1;
-		Error += TextureA[2] == TextureC[1] ? 0 : 1;
+		Error += (TextureA[1] == TextureC[0]) ? 0 : 1;
+		Error += (TextureA[2] == TextureC[1]) ? 0 : 1;
 
 		gli::texture3d TextureD(gli::duplicate(TextureC));
 
-		Error += TextureC == TextureD ? 0 : 1;
+		Error += (TextureC == TextureD) ? 0 : 1;
 
 		gli::texture3d TextureG(gli::duplicate(TextureA, 0, TextureA.levels() - 1));
-		Error += TextureA == TextureG ? 0 : 1;
+		Error += (TextureA == TextureG) ? 0 : 1;
 
 		gli::texture3d TextureE(gli::duplicate(TextureA, 1, TextureA.levels() - 1));
-		Error += TextureA[1] == TextureE[0] ? 0 : 1;
+		Error += (TextureA[1] == TextureE[0]) ? 0 : 1;
 
 		gli::texture3d TextureF(TextureA, 1, TextureA.levels() - 1); 
 
-		Error += TextureE == TextureF ? 0 : 1;
+		Error += (TextureE == TextureF) ? 0 : 1;
 	}
 
 	return Error;
 }
 
-int test_textureCube
-(
-	std::vector<gli::format> const & Formats,
-	gli::texture_cube::extent_type const & TextureSize
-)
-{
-	int Error(0);
+int test_textureCube(const std::vector<gli::format>& Formats, const gli::texture_cube::extent_type& TextureSize) {
+	int Error = 0;
 
-	for(std::size_t i = 0; i < Formats.size(); ++i)
-	{
+	for (const auto& Format: Formats) {
 		gli::texture_cube TextureA(
-			Formats[i],
+			Format,
 			gli::texture_cube::extent_type(TextureSize));
 
 		gli::texture_cube TextureB(gli::duplicate(TextureA));
 
-		Error += TextureA == TextureB ? 0 : 1;
+		Error += (TextureA == TextureB) ? 0 : 1;
 
 		gli::texture_cube TextureC(TextureA, 
-			gli::texture_cube::size_type(0), TextureA.faces() - 1,
-			gli::texture_cube::size_type(1), gli::texture_cube::size_type(2));
+			gli::texture_cube::size_type(0),
+			TextureA.faces() - 1,
+			gli::texture_cube::size_type(1),
+			gli::texture_cube::size_type(2));
 
-		Error += TextureA[0][1] == TextureC[0][0] ? 0 : 1;
-		Error += TextureA[0][2] == TextureC[0][1] ? 0 : 1;
-		Error += TextureA[1][1] == TextureC[1][0] ? 0 : 1;
-		Error += TextureA[1][2] == TextureC[1][1] ? 0 : 1;
+		Error += (TextureA[0][1] == TextureC[0][0]) ? 0 : 1;
+		Error += (TextureA[0][2] == TextureC[0][1]) ? 0 : 1;
+		Error += (TextureA[1][1] == TextureC[1][0]) ? 0 : 1;
+		Error += (TextureA[1][2] == TextureC[1][1]) ? 0 : 1;
 
 		gli::texture_cube TextureD(gli::duplicate(TextureC));
 
-		Error += TextureC == TextureD ? 0 : 1;
+		Error += (TextureC == TextureD) ? 0 : 1;
 
 		gli::texture_cube TextureG(gli::duplicate(
 			TextureA,
 			0, TextureA.faces() - 1,
 			0, TextureA.levels() - 1));
-		Error += TextureA == TextureG ? 0 : 1;
+		Error += (TextureA == TextureG) ? 0 : 1;
 
 		gli::texture_cube TextureE(gli::duplicate(
 			TextureA,
 			0, TextureA.faces() - 1,
 			0, TextureA.levels() - 1));
-		Error += TextureA[1] == TextureE[0] ? 0 : 1;
+		Error += (TextureA[1] == TextureE[0]) ? 0 : 1;
 
 		gli::texture_cube TextureF(
 			TextureA,
 			0, TextureA.faces() - 1,
 			0, TextureA.levels() - 1);
 
-		Error += TextureE == TextureF ? 0 : 1;
+		Error += (TextureE == TextureF) ? 0 : 1;
 
 		gli::texture_cube TextureK(
-			Formats[i],
+			Format,
 			TextureSize);
 
 		gli::texture_cube TextureH(TextureK, 0, 5, 1, 2);
 		gli::texture_cube TextureI(gli::duplicate(TextureH));
 
-		Error += TextureH == TextureI ? 0 : 1;
+		Error += (TextureH == TextureI) ? 0 : 1;
 
 		gli::texture_cube TextureJ(gli::duplicate(TextureK, 0, 5, 1, 2));
-		Error += TextureH == TextureJ ? 0 : 1;
-		Error += TextureI == TextureJ ? 0 : 1;
+		Error += (TextureH == TextureJ) ? 0 : 1;
+		Error += (TextureI == TextureJ) ? 0 : 1;
 	}
 
 	return Error;
 }
 
-int test_textureCubeArray
-(
-	std::vector<gli::format> const & Formats,
-	gli::texture_cube_array::extent_type const & TextureSize
-)
-{
-	int Error(0);
+int test_textureCubeArray(const std::vector<gli::format>& Formats, const gli::texture_cube_array::extent_type& TextureSize) {
+	int Error = 0;
 
-	for(std::size_t i = 0; i < Formats.size(); ++i)
-	{
+	for (const auto& Format: Formats) {
 		gli::texture_cube_array TextureA(
-			Formats[i],
+			Format,
 			TextureSize,
 			gli::texture_cube_array::size_type(4));
 
 		gli::texture_cube_array TextureB(gli::duplicate(TextureA));
 
-		Error += TextureA == TextureB ? 0 : 1;
+		Error += (TextureA == TextureB) ? 0 : 1;
 
 		gli::texture_cube_array TextureC(TextureA, 
-			gli::texture_cube_array::size_type(0), TextureA.layers() - 1,
-			gli::texture_cube_array::size_type(0), TextureA.faces() - 1,
-			gli::texture_cube_array::size_type(1), gli::texture_cube_array::size_type(2));
+			gli::texture_cube_array::size_type(0),
+			TextureA.layers() - 1,
+			gli::texture_cube_array::size_type(0),
+			TextureA.faces() - 1,
+			gli::texture_cube_array::size_type(1),
+			gli::texture_cube_array::size_type(2));
 
-		Error += TextureA[0][0][1] == TextureC[0][0][0] ? 0 : 1;
-		Error += TextureA[0][0][2] == TextureC[0][0][1] ? 0 : 1;
-		Error += TextureA[0][1][1] == TextureC[0][1][0] ? 0 : 1;
-		Error += TextureA[0][1][2] == TextureC[0][1][1] ? 0 : 1;
+		Error += (TextureA[0][0][1] == TextureC[0][0][0]) ? 0 : 1;
+		Error += (TextureA[0][0][2] == TextureC[0][0][1]) ? 0 : 1;
+		Error += (TextureA[0][1][1] == TextureC[0][1][0]) ? 0 : 1;
+		Error += (TextureA[0][1][2] == TextureC[0][1][1]) ? 0 : 1;
 
 		gli::texture_cube_array TextureD(gli::duplicate(TextureC));
 
-		Error += TextureC == TextureD ? 0 : 1;
+		Error += (TextureC == TextureD) ? 0 : 1;
 
 		gli::texture_cube_array TextureG(gli::duplicate(
 			TextureA,
-			gli::texture_cube_array::size_type(0), TextureA.layers() - 1,
-			gli::texture_cube_array::size_type(0), TextureA.faces() - 1,
-			gli::texture_cube_array::size_type(0), TextureA.levels() - 1));
-		Error += TextureA == TextureG ? 0 : 1;
+			gli::texture_cube_array::size_type(0),
+			TextureA.layers() - 1,
+			gli::texture_cube_array::size_type(0),
+			TextureA.faces() - 1,
+			gli::texture_cube_array::size_type(0),
+			TextureA.levels() - 1));
+		Error += (TextureA == TextureG) ? 0 : 1;
 
 		gli::texture_cube_array TextureK(
-			Formats[i],
+			Format,
 			TextureSize,
 			4);
 
 		gli::texture_cube_array TextureH(TextureK, 1, 2, 0, 5, 1, 2);
 		gli::texture_cube_array TextureI(gli::duplicate(TextureH));
 
-		Error += TextureH == TextureI ? 0 : 1;
+		Error += (TextureH == TextureI) ? 0 : 1;
 
 		gli::texture_cube_array TextureJ(gli::duplicate(TextureK, 1, 2, 0, 5, 1, 2));
-		Error += TextureH == TextureJ ? 0 : 1;
-		Error += TextureI == TextureJ ? 0 : 1;
+		Error += (TextureH == TextureJ) ? 0 : 1;
+		Error += (TextureI == TextureJ) ? 0 : 1;
 	}
 
 	return Error;
 }
 
-int main()
-{
-	int Error(0);
+int main() {
+	int Error = 0;
 
-	const int levels = gli::levels(1600);
+	// TODO: unused variable `levels` - use in tests or remove?
+	// const int levels = gli::levels(1600);
+	const std::size_t TextureSize = 32;
 
+	std::vector<gli::format> FormatsA = {
+		gli::FORMAT_RGBA8_UNORM_PACK8,
+		gli::FORMAT_RGB8_UNORM_PACK8,
+		gli::FORMAT_RGB_DXT1_UNORM_BLOCK8,
+		gli::FORMAT_RGBA_BP_UNORM_BLOCK16,
+		gli::FORMAT_RGBA32_SFLOAT_PACK32
+	};
 
-
-	std::vector<gli::format> FormatsA;
-	FormatsA.push_back(gli::FORMAT_RGBA8_UNORM_PACK8);
-	FormatsA.push_back(gli::FORMAT_RGB8_UNORM_PACK8);
-	FormatsA.push_back(gli::FORMAT_RGB_DXT1_UNORM_BLOCK8);
-	FormatsA.push_back(gli::FORMAT_RGBA_BP_UNORM_BLOCK16);
-	FormatsA.push_back(gli::FORMAT_RGBA32_SFLOAT_PACK32);
-
-	std::vector<gli::format> FormatsB;
-	FormatsB.push_back(gli::FORMAT_RGBA8_UNORM_PACK8);
-	FormatsB.push_back(gli::FORMAT_RGB8_UNORM_PACK8);
-	FormatsB.push_back(gli::FORMAT_RGBA32_SFLOAT_PACK32);
-
-	std::size_t const TextureSize = 32;
+	std::vector<gli::format> FormatsB = {
+		gli::FORMAT_RGBA8_UNORM_PACK8,
+		gli::FORMAT_RGB8_UNORM_PACK8,
+		gli::FORMAT_RGBA32_SFLOAT_PACK32
+	};
 
 	Error += test_texture1D(FormatsB, gli::texture1d::extent_type(TextureSize));
 	Error += test_texture1DArray(FormatsB, gli::texture1d_array::extent_type(TextureSize));

--- a/test/core/test_size.cpp
+++ b/test/core/test_size.cpp
@@ -4,77 +4,73 @@
 #include <gli/view.hpp>
 #include <gli/duplicate.hpp>
 
-namespace can_compute_texture_size
-{
-	int main()
-	{
+namespace can_compute_texture_size {
+	int main() {
 		int Error = 0;
 
 		// Scenario: Compute the size of a specialized 2d texture
 		{
 			gli::texture2d Texture(gli::FORMAT_RGBA8_UNORM_PACK8, gli::texture2d::extent_type(2), 1);
 
-			Error += Texture.size() == 2 * 2 * sizeof(glm::u8vec4) ? 0 : 1;
+			Error += (Texture.size() == 2 * 2 * sizeof(glm::u8vec4)) ? 0 : 1;
 			Error += Texture.size(0) == 2 * 2 * sizeof(glm::u8vec4) ? 0 : 1;
-			Error += Texture.size<glm::u8vec4>() == 2 * 2 ? 0 : 1;
-			Error += Texture.size<glm::u8vec4>(0) == 2 * 2 ? 0 : 1;
+			Error += (Texture.size<glm::u8vec4>() == 2 * 2) ? 0 : 1;
+			Error += (Texture.size<glm::u8vec4>(0) == 2 * 2) ? 0 : 1;
 		}
 
 		// Scenario: Compute the size of a generic 2d texture
 		{
 			gli::texture Texture(gli::TARGET_2D, gli::FORMAT_RGBA8_UNORM_PACK8, gli::texture::extent_type(2, 2, 1), 1, 1, 1);
 
-			Error += Texture.size() == 2 * 2 * sizeof(glm::u8vec4) ? 0 : 1;
-			Error += Texture.size(0) == 2 * 2 * sizeof(glm::u8vec4) ? 0 : 1;
-			Error += Texture.size<glm::u8vec4>() == 2 * 2 ? 0 : 1;
-			Error += Texture.size<glm::u8vec4>(0) == 2 * 2 ? 0 : 1;
+			Error += (Texture.size() == 2 * 2 * sizeof(glm::u8vec4)) ? 0 : 1;
+			Error += (Texture.size(0) == 2 * 2 * sizeof(glm::u8vec4)) ? 0 : 1;
+			Error += (Texture.size<glm::u8vec4>() == 2 * 2) ? 0 : 1;
+			Error += (Texture.size<glm::u8vec4>(0) == 2 * 2) ? 0 : 1;
 		}
 
 		// Scenario: Compute the size of a specialized 2d texture with a mipmap chain
 		{
 			gli::texture2d Texture(gli::FORMAT_RGBA8_UNORM_PACK8, gli::texture2d::extent_type(2));
 
-			Error += Texture.size() == 5 * sizeof(glm::u8vec4) ? 0 : 1;
-			Error += Texture.size(0) == 4 * sizeof(glm::u8vec4) ? 0 : 1;
-			Error += Texture.size(1) == 1 * sizeof(glm::u8vec4) ? 0 : 1;
-			Error += Texture.size<glm::u8vec4>() == 5 ? 0 : 1;
-			Error += Texture.size<glm::u8vec4>(0) == 4 ? 0 : 1;
-			Error += Texture.size<glm::u8vec4>(1) == 1 ? 0 : 1;
+			Error += (Texture.size() == 5 * sizeof(glm::u8vec4)) ? 0 : 1;
+			Error += (Texture.size(0) == 4 * sizeof(glm::u8vec4)) ? 0 : 1;
+			Error += (Texture.size(1) == 1 * sizeof(glm::u8vec4)) ? 0 : 1;
+			Error += (Texture.size<glm::u8vec4>() == 5) ? 0 : 1;
+			Error += (Texture.size<glm::u8vec4>(0) == 4) ? 0 : 1;
+			Error += (Texture.size<glm::u8vec4>(1) == 1) ? 0 : 1;
 		}
 
 		// Scenario: Compute the size of a generic 2d texture with a mipmap chain
 		{
 			gli::texture Texture(gli::TARGET_2D, gli::FORMAT_RGBA8_UNORM_PACK8, gli::texture::extent_type(2, 2, 1), 1, 1, 2);
 
-			Error += Texture.size() == 5 * sizeof(glm::u8vec4) ? 0 : 1;
-			Error += Texture.size(0) == 4 * sizeof(glm::u8vec4) ? 0 : 1;
-			Error += Texture.size(1) == 1 * sizeof(glm::u8vec4) ? 0 : 1;
-			Error += Texture.size<glm::u8vec4>() == 5 ? 0 : 1;
-			Error += Texture.size<glm::u8vec4>(0) == 4 ? 0 : 1;
-			Error += Texture.size<glm::u8vec4>(1) == 1 ? 0 : 1;
+			Error += (Texture.size() == 5 * sizeof(glm::u8vec4)) ? 0 : 1;
+			Error += (Texture.size(0) == 4 * sizeof(glm::u8vec4)) ? 0 : 1;
+			Error += (Texture.size(1) == 1 * sizeof(glm::u8vec4)) ? 0 : 1;
+			Error += (Texture.size<glm::u8vec4>() == 5) ? 0 : 1;
+			Error += (Texture.size<glm::u8vec4>(0) == 4) ? 0 : 1;
+			Error += (Texture.size<glm::u8vec4>(1) == 1) ? 0 : 1;
 		}
 
 		return Error;
 	}
-}//namespace can_compute_texture_size
+} // namespace can_compute_texture_size
 
-namespace can_compute_view_size
-{
-	int main()
-	{
+namespace can_compute_view_size {
+	int main() {
 		int Error = 0;
 
 		// Scenario: Compute the size of a specialized 2d texture with a mipmap chain
 		{
-			gli::texture2d Texture(gli::FORMAT_RGBA8_UNORM_PACK8, gli::texture2d::extent_type(4));
+			gli::texture2d Texture(gli::FORMAT_RGBA8_UNORM_PACK8, static_cast<gli::texture2d::extent_type>(4));
 			gli::texture2d View(gli::view(Texture, 1, 2));
 
-			Error += View.size() == 5 * sizeof(glm::u8vec4) ? 0 : 1;
-			Error += View.size(0) == 4 * sizeof(glm::u8vec4) ? 0 : 1;
-			Error += View.size(1) == 1 * sizeof(glm::u8vec4) ? 0 : 1;
-			Error += View.size<glm::u8vec4>() == 5 ? 0 : 1;
-			Error += View.size<glm::u8vec4>(0) == 4 ? 0 : 1;
-			Error += View.size<glm::u8vec4>(1) == 1 ? 0 : 1;
+			Error += (View.size() == 5 * sizeof(glm::u8vec4)) ? 0 : 1;
+			Error += (View.size(0) == 4 * sizeof(glm::u8vec4)) ? 0 : 1;
+			Error += (View.size(1) == 1 * sizeof(glm::u8vec4)) ? 0 : 1;
+			Error += (View.size<glm::u8vec4>() == 5) ? 0 : 1;
+			Error += (View.size<glm::u8vec4>(0) == 4) ? 0 : 1;
+			Error += (View.size<glm::u8vec4>(1) == 1) ? 0 : 1;
 		}
 
 		// Scenario: Compute the size of a generic 2d texture with a mipmap chain
@@ -82,126 +78,128 @@ namespace can_compute_view_size
 			gli::texture Texture(gli::TARGET_2D, gli::FORMAT_RGBA8_UNORM_PACK8, gli::texture::extent_type(4, 4, 1), 1, 1, 3);
 			gli::texture View(gli::view(gli::texture2d(Texture), 1, 2));
 
-			Error += View.size() == 5 * sizeof(glm::u8vec4) ? 0 : 1;
-			Error += View.size(0) == 4 * sizeof(glm::u8vec4) ? 0 : 1;
-			Error += View.size(1) == 1 * sizeof(glm::u8vec4) ? 0 : 1;
-			Error += View.size<glm::u8vec4>() == 5 ? 0 : 1;
-			Error += View.size<glm::u8vec4>(0) == 4 ? 0 : 1;
-			Error += View.size<glm::u8vec4>(1) == 1 ? 0 : 1;
+			Error += (View.size() == 5 * sizeof(glm::u8vec4)) ? 0 : 1;
+			Error += (View.size(0) == 4 * sizeof(glm::u8vec4)) ? 0 : 1;
+			Error += (View.size(1) == 1 * sizeof(glm::u8vec4)) ? 0 : 1;
+			Error += (View.size<glm::u8vec4>() == 5) ? 0 : 1;
+			Error += (View.size<glm::u8vec4>(0) == 4) ? 0 : 1;
+			Error += (View.size<glm::u8vec4>(1) == 1) ? 0 : 1;
 		}
 
 		// Scenario: Compute the size of a specialized 2d array texture with a mipmap chain
 		{
-			gli::texture2d_array Texture(gli::FORMAT_RGBA8_UNORM_PACK8, gli::texture2d::extent_type(4), 2);
+			gli::texture2d_array Texture(gli::FORMAT_RGBA8_UNORM_PACK8, static_cast<gli::texture2d::extent_type>(4), 2);
 			gli::texture2d_array View(gli::view(Texture, 1, 1, 1, 2));
 
-			Error += View.size() == 5 * sizeof(glm::u8vec4) ? 0 : 1;
-			Error += View.size(0) == 4 * sizeof(glm::u8vec4) ? 0 : 1;
-			Error += View.size(1) == 1 * sizeof(glm::u8vec4) ? 0 : 1;
-			Error += View.size<glm::u8vec4>() == 5 ? 0 : 1;
-			Error += View.size<glm::u8vec4>(0) == 4 ? 0 : 1;
-			Error += View.size<glm::u8vec4>(1) == 1 ? 0 : 1;
+			Error += (View.size() == 5 * sizeof(glm::u8vec4)) ? 0 : 1;
+			Error += (View.size(0) == 4 * sizeof(glm::u8vec4)) ? 0 : 1;
+			Error += (View.size(1) == 1 * sizeof(glm::u8vec4)) ? 0 : 1;
+			Error += (View.size<glm::u8vec4>() == 5) ? 0 : 1;
+			Error += (View.size<glm::u8vec4>(0) == 4) ? 0 : 1;
+			Error += (View.size<glm::u8vec4>(1) == 1) ? 0 : 1;
 		}
 
 		return Error;
 	}
-}//namespace can_compute_view_size
+} // namespace can_compute_view_size
 
 namespace can_compute_npot_texture_size
 {
-	int main()
-	{
+	int main() {
 		int Error = 0;
 
 		{
 			gli::storage_linear Storage(gli::FORMAT_RGBA8_UNORM_PACK8, gli::storage_linear::extent_type(12, 12, 1), 1, 1, gli::levels(12));
 
-			gli::size_t const LevelSize0 = Storage.level_size(0);
-			Error += LevelSize0 == 12 * 12 * sizeof(glm::u8vec4) ? 0 : 1;
+			const gli::size_t LevelSize0 = Storage.level_size(0);
+			Error += (LevelSize0 == 12 * 12 * sizeof(glm::u8vec4)) ? 0 : 1;
 
-			gli::size_t const LevelSize1 = Storage.level_size(1);
-			Error += LevelSize1 == 6 * 6 * sizeof(glm::u8vec4) ? 0 : 1;
+			const gli::size_t LevelSize1 = Storage.level_size(1);
+			Error += (LevelSize1 == 6 * 6 * sizeof(glm::u8vec4)) ? 0 : 1;
 
-			gli::size_t const LevelSize2 = Storage.level_size(2);
-			Error += LevelSize2 == 3 * 3 * sizeof(glm::u8vec4) ? 0 : 1;
+			const gli::size_t LevelSize2 = Storage.level_size(2);
+			Error += (LevelSize2 == 3 * 3 * sizeof(glm::u8vec4)) ? 0 : 1;
 
-			gli::size_t const LevelSize3 = Storage.level_size(3);
-			Error += LevelSize3 == 1 * 1 * sizeof(glm::u8vec4) ? 0 : 1;
+			const gli::size_t LevelSize3 = Storage.level_size(3);
+			Error += (LevelSize3 == 1 * 1 * sizeof(glm::u8vec4)) ? 0 : 1;
 		}
 
 		{
 			gli::storage_linear Storage(gli::FORMAT_RGB_DXT1_UNORM_BLOCK8, gli::storage_linear::extent_type(12, 12, 1), 1, 1, gli::levels(12));
-			gli::size_t const LevelSize0 = Storage.level_size(0);
-			gli::size_t const LevelSizeA = 3 * 3 * gli::block_size(gli::FORMAT_RGB_DXT1_UNORM_BLOCK8);
-			Error += LevelSize0 == LevelSizeA ? 0 : 1;
+			const gli::size_t LevelSize0 = Storage.level_size(0);
+			const gli::size_t LevelSizeA = 3 * 3 * gli::block_size(gli::FORMAT_RGB_DXT1_UNORM_BLOCK8);
+			Error += (LevelSize0 == LevelSizeA) ? 0 : 1;
 
-			gli::size_t const LevelSize1 = Storage.level_size(1);
-			gli::size_t const LevelSizeB = 2 * 2 * gli::block_size(gli::FORMAT_RGB_DXT1_UNORM_BLOCK8);
-			Error += LevelSize1 == LevelSizeB ? 0 : 1;
+			const gli::size_t LevelSize1 = Storage.level_size(1);
+			const gli::size_t LevelSizeB = 2 * 2 * gli::block_size(gli::FORMAT_RGB_DXT1_UNORM_BLOCK8);
+			Error += (LevelSize1 == LevelSizeB) ? 0 : 1;
 
-			gli::size_t const LevelSize2 = Storage.level_size(2);
-			gli::size_t const LevelSizeC = 1 * 1 * gli::block_size(gli::FORMAT_RGB_DXT1_UNORM_BLOCK8);
-			Error += LevelSize2 == LevelSizeC ? 0 : 1;
+			const gli::size_t LevelSize2 = Storage.level_size(2);
+			const gli::size_t LevelSizeC = 1 * 1 * gli::block_size(gli::FORMAT_RGB_DXT1_UNORM_BLOCK8);
+			Error += (LevelSize2 == LevelSizeC) ? 0 : 1;
 
-			gli::size_t const LevelSize3 = Storage.level_size(3);
-			Error += LevelSize3 == LevelSizeC ? 0 : 1;
+			const gli::size_t LevelSize3 = Storage.level_size(3);
+			Error += (LevelSize3 == LevelSizeC) ? 0 : 1;
+		}
+
+		/* TODO: unused variables - add tests or remove?
+		{
+			gli::texture::extent_type const BlockCountA = glm::max(gli::texture::extent_type(5, 5, 1) / gli::block_extent(gli::FORMAT_RGB_DXT1_UNORM_BLOCK8),
+					static_cast<gli::texture::extent_type>(1));
+
+			gli::texture::extent_type const BlockCountB = glm::ceilMultiple(gli::texture::extent_type(5, 5, 1),
+					gli::block_extent(gli::FORMAT_RGB_DXT1_UNORM_BLOCK8)) / gli::block_extent(gli::FORMAT_RGB_DXT1_UNORM_BLOCK8);
+		}
+		*/
+
+		{
+			gli::texture2d Texture(gli::FORMAT_RGBA8_UNORM_PACK8, static_cast<gli::texture2d::extent_type>(5));
+
+			const gli::texture2d::size_type SizeA1 = Texture.size();
+			const gli::texture2d::size_type SizeA2 = ((5 * 5) + (2 * 2) + 1) * sizeof(glm::u8vec4);
+			Error += (SizeA1 == SizeA2) ? 0 : 1;
+
+			const gli::texture2d::size_type SizeB1 = Texture.size(0);
+			const gli::texture2d::size_type SizeB2 = (5 * 5) * sizeof(glm::u8vec4);
+			Error += (SizeB1 == SizeB2) ? 0 : 1;
+
+			const gli::texture2d::size_type SizeC1 = Texture.size(1);
+			const gli::texture2d::size_type SizeC2 = (2 * 2) * sizeof(glm::u8vec4);
+			Error += (SizeC1 == SizeC2) ? 0 : 1;
+
+			const gli::texture2d::size_type SizeD1 = Texture.size(2);
+			const gli::texture2d::size_type SizeD2 = (1 * 1) * sizeof(glm::u8vec4);
+			Error += (SizeD1 == SizeD2) ? 0 : 1;
 		}
 
 		{
-			gli::texture::extent_type const BlockCountA = glm::max(gli::texture::extent_type(5, 5, 1) / gli::block_extent(gli::FORMAT_RGB_DXT1_UNORM_BLOCK8), gli::texture::extent_type(1));
+			gli::texture2d Texture(gli::FORMAT_RGBA8_UNORM_PACK8, static_cast<gli::texture2d::extent_type>(3));
 
-			gli::texture::extent_type const BlockCountB = glm::ceilMultiple(gli::texture::extent_type(5, 5, 1), gli::block_extent(gli::FORMAT_RGB_DXT1_UNORM_BLOCK8)) / gli::block_extent(gli::FORMAT_RGB_DXT1_UNORM_BLOCK8);
+			Error += (Texture.size() == (3 * 3 + 1) * sizeof(glm::u8vec4)) ? 0 : 1;
+			Error += (Texture.size(0) == (3 * 3) * sizeof(glm::u8vec4)) ? 0 : 1;
+			Error += (Texture.size(1) == (1 * 1) * sizeof(glm::u8vec4)) ? 0 : 1;
 		}
 
 		{
-			gli::texture2d Texture(gli::FORMAT_RGBA8_UNORM_PACK8, gli::texture2d::extent_type(5));
+			gli::texture2d Texture(gli::FORMAT_RGB_DXT1_UNORM_BLOCK8, static_cast<gli::texture2d::extent_type>(3), 1);
 
-			gli::texture2d::size_type const SizeA1 = Texture.size();
-			gli::texture2d::size_type const SizeA2 = ((5 * 5) + (2 * 2) + 1) * sizeof(glm::u8vec4);
-			Error += SizeA1 == SizeA2 ? 0 : 1;
-
-			gli::texture2d::size_type const SizeB1 = Texture.size(0);
-			gli::texture2d::size_type const SizeB2 = (5 * 5) * sizeof(glm::u8vec4);
-			Error += SizeB1 == SizeB2 ? 0 : 1;
-
-			gli::texture2d::size_type const SizeC1 = Texture.size(1);
-			gli::texture2d::size_type const SizeC2 = (2 * 2) * sizeof(glm::u8vec4);
-			Error += SizeC1 == SizeC2 ? 0 : 1;
-
-			gli::texture2d::size_type const SizeD1 = Texture.size(2);
-			gli::texture2d::size_type const SizeD2 = (1 * 1) * sizeof(glm::u8vec4);
-			Error += SizeD1 == SizeD2 ? 0 : 1;
-		}
-
-		{
-			gli::texture2d Texture(gli::FORMAT_RGBA8_UNORM_PACK8, gli::texture2d::extent_type(3));
-
-			Error += Texture.size() == (3 * 3 + 1) * sizeof(glm::u8vec4) ? 0 : 1;
-			Error += Texture.size(0) == (3 * 3) * sizeof(glm::u8vec4) ? 0 : 1;
-			Error += Texture.size(1) == (1 * 1) * sizeof(glm::u8vec4) ? 0 : 1;
-		}
-
-		{
-			gli::texture2d Texture(gli::FORMAT_RGB_DXT1_UNORM_BLOCK8, gli::texture2d::extent_type(3), 1);
-
-			Error += Texture.size() == gli::block_size(gli::FORMAT_RGB_DXT1_UNORM_BLOCK8) ? 0 : 1;
+			Error += (Texture.size() == gli::block_size(gli::FORMAT_RGB_DXT1_UNORM_BLOCK8)) ? 0 : 1;
 		}
 
 		{
 			gli::texture2d Texture(gli::FORMAT_RGB_DXT1_UNORM_BLOCK8, gli::texture2d::extent_type(9, 5), 1);
 
-			gli::texture2d::size_type const CurrentSize = Texture.size();
-			gli::texture2d::size_type const ExpectedSize = gli::block_size(gli::FORMAT_RGB_DXT1_UNORM_BLOCK8) * 3 * 2;
+			const gli::texture2d::size_type CurrentSize = Texture.size();
+			const gli::texture2d::size_type ExpectedSize = gli::block_size(gli::FORMAT_RGB_DXT1_UNORM_BLOCK8) * 3 * 2;
 
-			Error += CurrentSize == ExpectedSize ? 0 : 1;
+			Error += (CurrentSize == ExpectedSize) ? 0 : 1;
 		}
 
 		return Error;
 	}
-}//namespace can_compute_npot_texture_size
+} // namespace can_compute_npot_texture_size
 
-int main()
-{
+int main() {
 	int Error = 0;
 
 	Error += can_compute_npot_texture_size::main();

--- a/test/core/texture_lod_sampler2d.cpp
+++ b/test/core/texture_lod_sampler2d.cpp
@@ -1,15 +1,15 @@
-#include <gli/sampler2d.hpp>
-#include <gli/comparison.hpp>
-#include <glm/ext/vector_relational.hpp>
 #include <ctime>
 #include <limits>
 #include <array>
 
-namespace load
-{
-	int test()
-	{
-		int Error(0);
+#include <gli/sampler2d.hpp>
+#include <gli/comparison.hpp>
+
+#include <glm/ext/vector_relational.hpp>
+
+namespace load {
+	int test() {
+		int Error = 0;
 
 		gli::texture2d Texture(gli::FORMAT_RGBA8_UNORM_PACK8, gli::texture2d::extent_type(4, 2), 1);
 		*(Texture.data<glm::u8vec4>() + 0) = glm::u8vec4(255,   0,   0, 255);
@@ -41,12 +41,10 @@ namespace load
 
 		return Error;
 	}
-}//namespace load
+} // namespace load
 
-namespace texture_lod
-{
-	int test()
-	{
+namespace texture_lod {
+	int test() {
 		int Error = 0;
 
 		{
@@ -61,29 +59,33 @@ namespace texture_lod
 			Texture.store(gli::extent2d(2, 3), 0, gli::u8vec4(  0, 127, 255, 255));
 			Texture.store(gli::extent2d(3, 3), 0, gli::u8vec4(  0, 127, 255, 255));
 
-			gli::sampler2d<float> const Sampler(Texture, gli::WRAP_CLAMP_TO_EDGE, gli::FILTER_LINEAR, gli::FILTER_LINEAR, gli::vec4(1.0f, 0.5f, 0.0f, 1.0f));
+			const gli::sampler2d<float> Sampler(Texture,
+					gli::WRAP_CLAMP_TO_EDGE,
+					gli::FILTER_LINEAR,
+					gli::FILTER_LINEAR,
+					gli::vec4(1.0f, 0.5f, 0.0f, 1.0f));
 
-			gli::vec4 const SampleA = Sampler.texture_lod(gli::fsampler2D::normalized_type(0.25f), 0.0f);
+			const gli::vec4 SampleA = Sampler.texture_lod(gli::fsampler2D::normalized_type(0.25f), 0.0f);
 			Error += gli::all(glm::equal(SampleA, gli::vec4(1.0f, 0.5f, 0.0f, 1.0f), 0.01f)) ? 0 : 1;
 
-			gli::vec4 const SampleB = Sampler.texture_lod(gli::fsampler2D::normalized_type(0.8f), 0.0f);
+			const gli::vec4 SampleB = Sampler.texture_lod(gli::fsampler2D::normalized_type(0.8f), 0.0f);
 			Error += gli::all(glm::equal(SampleB, gli::vec4(0.0f, 0.5f, 1.0f, 1.0f), 0.01f)) ? 0 : 1;
 
-			gli::vec4 const SampleC = Sampler.texture_lod(gli::fsampler2D::normalized_type(0.20f, 0.8f), 0.0f);
+			const gli::vec4 SampleC = Sampler.texture_lod(gli::fsampler2D::normalized_type(0.20f, 0.8f), 0.0f);
 			Error += gli::all(glm::equal(SampleC, gli::vec4(0.0f, 0.0f, 0.0f, 1.0f), 0.01f)) ? 0 : 1;
 
-			gli::vec4 const SampleD = Sampler.texture_grad(gli::fsampler2D::normalized_type(0.25f), gli::fsampler2D::normalized_type(0.0f), gli::fsampler2D::normalized_type(0.0f));
-			Error += gli::all(glm::equal(SampleA, gli::vec4(1.0f, 0.5f, 0.0f, 1.0f), 0.01f)) ? 0 : 1;
+			const gli::vec4 SampleD = Sampler.texture_grad(gli::fsampler2D::normalized_type(0.25f),
+					gli::fsampler2D::normalized_type(0.0f),
+					gli::fsampler2D::normalized_type(0.0f));
+			Error += gli::all(glm::equal(SampleD, gli::vec4(1.0f, 0.5f, 0.0f, 1.0f), 0.01f)) ? 0 : 1;
 		}
 
 		return Error;
 	}
-}//namespace texture_lod
+} // namespace texture_lod
 
-namespace sampler_type
-{
-	int test()
-	{
+namespace sampler_type {
+	int test() {
 		int Error = 0;
 
 		{
@@ -103,11 +105,10 @@ namespace sampler_type
 		
 		return Error;
 	}
-}//namespace sampler_type
+} // namespace sampler_type
 
-int main()
-{
-	int Error(0);
+int main() {
+	int Error = 0;
 
 	Error += texture_lod::test();
 	Error += load::test();


### PR DESCRIPTION
Building GLI with GCC works, however it doesn't with Clang and for good reasons. The code base contains a number of operations like this one, which the LLVM toolchain deems illegal:
```cpp
        // strstr returns a pointer to char, not an int
	if(std::strstr(FilenameDst, ".dds") > 0 || std::strstr(FilenameDst, ".ktx") > 0)
		return false;
```
Other suspicious operations raise warnings, meaning that the compiler permits them, but they can lead to runtime issues like overflows.

This PR tries to address some code style issues in the affected source files as well.