### PR TITLE
Add LLVM/Clang10 to Travis CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ jobs:
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
+            - bionic-updates
           packages:
             - llvm-toolchain-10
       env: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ branches:
 compiler:
   - clang   # clang 7
   - clang-9
+  - clang-10
   - gcc     # gcc 7.4
   - gcc-9
   - gcc-10
@@ -28,6 +29,15 @@ jobs:
             - clang-9
       env: 
         - MATRIX_EVAL="CC=clang-9 CXX=clang++-9"
+
+    - compiler: clang-10
+    - name: "Build with LLVM/Clang 10"
+      addons:
+        apt:
+          packages:
+            - llvm-toolchain-10
+      env: 
+        - MATRIX_EVAL="CC=clang-10 CXX=clang++-10"
 
     - compiler: gcc
     - name: "Build with GCC 7.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,12 +32,10 @@ jobs:
 
     - compiler: clang-10
     - name: "Build with LLVM/Clang 10"
-      addons:
-        apt:
-          sources:
-            - bionic-updates
-          packages:
-            - llvm-toolchain-10
+      script:
+        - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+        - sudo add-apt-repository -u 'http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main'
+        - sudo apt update && sudo apt install clang-10
       env: 
         - MATRIX_EVAL="CC=clang-10 CXX=clang++-10"
 
@@ -71,16 +69,16 @@ jobs:
         - MATRIX_EVAL="CC=gcc-10 CXX=g++-10"
 
 before_script: 
-- cmake --version
-- eval "${MATRIX_EVAL}"
-- $CC --version
-- $CXX --version
+  - cmake --version
+  - eval "${MATRIX_EVAL}"
+  - $CC --version
+  - $CXX --version
 
 script:
-- mkdir ./build
-- cd ./build
-- cmake ..
-- cmake --build .
-- ctest
-- cd ..
+  - mkdir ./build
+  - cd ./build
+  - cmake ..
+  - cmake --build .
+  - ctest
+  - cd ..
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ jobs:
       script:
         - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         - sudo add-apt-repository -u 'http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main'
-        - sudo apt update && sudo apt install clang-10
+        - sudo apt update && sudo apt install -y clang-10
       env: 
         - MATRIX_EVAL="CC=clang-10 CXX=clang++-10"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,8 @@ jobs:
     - name: "Build with LLVM/Clang 10"
       addons:
         apt:
+          sources:
+            - ubuntu-toolchain-r-test
           packages:
             - llvm-toolchain-10
       env: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,66 +19,69 @@ jobs:
     - compiler: clang
     - name: "Build with LLVM/Clang 7"
       env: 
-        - MATRIX_EVAL="CC=clang CXX=clang++"
+      - MATRIX_EVAL="CC=clang CXX=clang++"
 
     - compiler: clang-9
     - name: "Build with LLVM/Clang 9"
       addons:
         apt:
           packages:
-            - clang-9
+          - clang-9
       env: 
-        - MATRIX_EVAL="CC=clang-9 CXX=clang++-9"
+      - MATRIX_EVAL="CC=clang-9 CXX=clang++-9"
 
     - compiler: clang-10
     - name: "Build with LLVM/Clang 10"
-      script:
-        - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-        - sudo add-apt-repository -u 'http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main'
-        - sudo apt update && sudo apt install -y clang-10
+      addons:
+        apt:
+          sources:
+          - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main'
+          key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+          packages:
+          - clang-10
       env: 
-        - MATRIX_EVAL="CC=clang-10 CXX=clang++-10"
+      - MATRIX_EVAL="CC=clang-10 CXX=clang++-10"
 
     - compiler: gcc
     - name: "Build with GCC 7.4"
       env: 
-        - MATRIX_EVAL="CC=gcc CXX=g++"
+      - MATRIX_EVAL="CC=gcc CXX=g++"
 
     - compiler: gcc-9
     - name: "Build with GCC 9"
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
+          - ubuntu-toolchain-r-test
           packages:
-            - gcc-9
-            - g++-9
+          - gcc-9
+          - g++-9
       env: 
-        - MATRIX_EVAL="CC=gcc-9 CXX=g++-9"
+      - MATRIX_EVAL="CC=gcc-9 CXX=g++-9"
 
     - compiler: gcc-10
     - name: "Build with GCC 10"
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
+          - ubuntu-toolchain-r-test
           packages:
-            - gcc-10
-            - g++-10
+          - gcc-10
+          - g++-10
       env: 
-        - MATRIX_EVAL="CC=gcc-10 CXX=g++-10"
+      - MATRIX_EVAL="CC=gcc-10 CXX=g++-10"
 
 before_script: 
-  - cmake --version
-  - eval "${MATRIX_EVAL}"
-  - $CC --version
-  - $CXX --version
+- cmake --version
+- eval "${MATRIX_EVAL}"
+- $CC --version
+- $CXX --version
 
 script:
-  - mkdir ./build
-  - cd ./build
-  - cmake ..
-  - cmake --build .
-  - ctest
-  - cd ..
+- mkdir ./build
+- cd ./build
+- cmake ..
+- cmake --build .
+- ctest
+- cd ..
 


### PR DESCRIPTION
I use Clang10 locally on Fedora anyway and GLI builds without issues with it so I'm going to add it to the build matrix.